### PR TITLE
Fix account dropdown overflow

### DIFF
--- a/adventure/views/head.ejs
+++ b/adventure/views/head.ejs
@@ -41,7 +41,7 @@
                     <a class="nav-link dropdown-toggle" href="#" id="userMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                         <%= user.ShortName %>
                     </a>
-                    <div class="dropdown-menu" aria-labelledby="userMenuLink">
+                    <div class="dropdown-menu dropdown-menu-right" aria-labelledby="userMenuLink">
                         <a class="dropdown-item" href="/user/edit">Edit profile</a>
                         <a class="dropdown-item" href="/user/logout">Log out</a>
                     </div>


### PR DESCRIPTION
Dropdown currently flows out of browser window as shown in the image below. Adding the dropdown-menu-right class fixes this.

![image](https://user-images.githubusercontent.com/11572143/31249798-56d14286-aa21-11e7-9639-f68b8803391d.png)
