### PR TITLE
Changed "Search" text in search button to a search icon glyph

### DIFF
--- a/adventure/views/head.ejs
+++ b/adventure/views/head.ejs
@@ -7,6 +7,7 @@
     <meta name="description" content="WinWorld is a free online museum dedicated to the preservation of old software." />
     <meta name="keywords" content="winworld, winboards, abandonware, technology, museum, dos, windows, microsoft, apple" />
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta/css/bootstrap.min.css" integrity="sha384-/Y6pD6FV/Vv2HJnA6t+vslU6fwYXjCFtcEpHbNJ0lyAFsXTsjBbfaDjzALeQsN6M" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
     <!-- TODO: Move to linked stylesheet in /res/ -->
     <link rel="stylesheet" href="/res/css/stickyFooter.css" />
     <title>WinWorld: <%= title %></title>
@@ -33,7 +34,9 @@
             </ul>
             <form class="form-inline my-2 my-lg-0 mr-2" action="/search">
                 <input class="form-control mr-sm-2" type="search" name="q" placeholder="Search" aria-label="Search" required value="<%= typeof q == 'undefined' ? '' : q %>">
-                <button class="btn btn-outline-primary my-2 my-sm-0" type="submit">Search</button>
+                <button class="btn btn-outline-primary my-2 my-sm-0" type="submit">
+                    <i class="material-icons">search<i>
+		</button>
             </form>
             <ul class="nav navbar-nav">
                 <% if (user) { %>


### PR DESCRIPTION
Resolves issue #20 by changing the "Search" text on the button for the search field in the header to the `search` glyph provided by Google's Material Icons.
This, of course, shouldn't be merged right away if another set of glyphs, such as Font Awesome, should be used instead. Let me know if that is the case, and I will make the appropriate modifications.