### PR TITLE
IPFS support and minor fixes (SQL + .gitignore)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -243,3 +243,5 @@ ModelManifest.xml
 
 # typings
 typings/
+
+config.json

--- a/adventure/adventure.njsproj
+++ b/adventure/adventure.njsproj
@@ -7,7 +7,7 @@
     <RootNamespace>adventure</RootNamespace>
     <NodejsPort>3000</NodejsPort>
     <LaunchUrl>http://localhost:3000/</LaunchUrl>
-    <ScriptArguments>config.example.json</ScriptArguments>
+    <ScriptArguments>config.json</ScriptArguments>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>

--- a/adventure/deploy/install.sql
+++ b/adventure/deploy/install.sql
@@ -107,6 +107,7 @@ CREATE TABLE IF NOT EXISTS `downloads` (
   `LastUpdated` timestamp NULL DEFAULT current_timestamp(),
   `NoShowOnHome` enum('True','False') COLLATE utf8_bin NOT NULL DEFAULT 'False',
   `FileHash` varchar(255) COLLATE utf8_bin DEFAULT NULL,
+  `IPFSPath` TEXT NULL DEFAULT NULL COLLATE 'utf8_bin',
   PRIMARY KEY (`DLUUID`),
   KEY `ReleaseUUID` (`ReleaseUUID`),
   KEY `FileName` (`Name`),

--- a/adventure/deploy/install.sql
+++ b/adventure/deploy/install.sql
@@ -234,9 +234,7 @@ CREATE TABLE IF NOT EXISTS `UserFlagHolders` (
 -- Dumping data for table winworld.UserFlagHolders: ~2 rows (approximately)
 /*!40000 ALTER TABLE `UserFlagHolders` DISABLE KEYS */;
 INSERT IGNORE INTO `UserFlagHolders` (`FlagUUID`, `UserUUID`, `Added`) VALUES
-	(_binary 0x557074696D6500006500630074006500, _binary 0x000000000000000000000000205CA002, '2017-08-02 04:26:41'),
-	(_binary 0x25C5A043C3867BC2B311C3A4C29D7100, _binary 0x7B05DE4D3F2111E88D2AFA163E9022F0, '2017-08-02 04:26:41'),
-	(_binary 0x11E99BFCD1E51F4C853FE86A64A6C64B, _binary 0x11E99C2A69150375A00AE86A64A6C64B, '2019-07-01 20:05:16');
+	(_binary 0x11E99BFCD1E51F4C853FE86A64A6C64B, _binary 0x11E99BFCD1E9E3F7853FE86A64A6C64B, NOW());
 /*!40000 ALTER TABLE `UserFlagHolders` ENABLE KEYS */;
 
 -- Dumping structure for table winworld.UserFlags
@@ -292,7 +290,7 @@ CREATE TABLE IF NOT EXISTS `Users` (
 -- Dumping data for table winworld.Users: ~0 rows (approximately)
 /*!40000 ALTER TABLE `Users` DISABLE KEYS */;
 INSERT IGNORE INTO `Users` (`UserID`, `Email`, `AccountEnabled`, `Password`, `Salt`, `ShortName`, `RegistrationTime`, `LastSeenTime`, `RegistrationIP`, `ThemeName`) VALUES
-	(_binary 0x11E99BFCD1E9E3F7853FE86A64A6C64B, 'root@localhost', 'True', '$2a$12$I7Z0lrQFyxgRFgWVB8FX1.FYpJDEN7Z5x4Mp4a7I8bT26G3OU8USa', '', 'admin', '2019-07-01 14:36:16', '2018-04-07 00:27:28', '', 'default');
+	(_binary 0x11E99BFCD1E9E3F7853FE86A64A6C64B, 'root@localhost', 'True', '$2a$12$I7Z0lrQFyxgRFgWVB8FX1.FYpJDEN7Z5x4Mp4a7I8bT26G3OU8USa', '', 'admin', NOW(), NOW(), '', 'default');
 /*!40000 ALTER TABLE `Users` ENABLE KEYS */;
 
 -- Dumping structure for function winworld.UUIDBIN

--- a/adventure/deploy/install.sql
+++ b/adventure/deploy/install.sql
@@ -1,7 +1,7 @@
 -- --------------------------------------------------------
 -- Host:                         127.0.0.1
--- Server version:               10.4.6-MariaDB - mariadb.org binary distribution
--- Server OS:                    Win64
+-- Server version:               10.1.40-MariaDB-0ubuntu0.18.04.1 - Ubuntu 18.04
+-- Server OS:                    debian-linux-gnu
 -- HeidiSQL Version:             9.5.0.5196
 -- --------------------------------------------------------
 
@@ -11,8 +11,8 @@
 /*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
 /*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
 
--- Dumping structure for table winworld.contributions
-CREATE TABLE IF NOT EXISTS `contributions` (
+-- Dumping structure for table winworld.Contributions
+CREATE TABLE IF NOT EXISTS `Contributions` (
   `ContributionUUID` binary(16) NOT NULL,
   `UserUUID` binary(16) NOT NULL,
   `ProductTitle` varchar(100) COLLATE utf8_bin NOT NULL,
@@ -25,35 +25,35 @@ CREATE TABLE IF NOT EXISTS `contributions` (
   `CPURequirement` varchar(150) COLLATE utf8_bin DEFAULT NULL,
   `RAMRequirement` int(10) unsigned DEFAULT NULL,
   `DiskRequirement` int(10) unsigned DEFAULT NULL,
-  `AboutRelease` text COLLATE utf8_bin DEFAULT NULL,
-  `InstallInstructions` text COLLATE utf8_bin DEFAULT NULL,
+  `AboutRelease` text COLLATE utf8_bin,
+  `InstallInstructions` text COLLATE utf8_bin,
   `FTPUser` varchar(50) COLLATE utf8_bin DEFAULT NULL,
   `FTPPassword` varchar(350) COLLATE utf8_bin DEFAULT NULL,
   `FTPUploadDirectory` varchar(350) COLLATE utf8_bin DEFAULT NULL,
   `Status` enum('New','Uploaded','Processing','Public','Verified','Rejected') COLLATE utf8_bin NOT NULL DEFAULT 'New',
   `FTPAccountEnabled` set('True','False') COLLATE utf8_bin NOT NULL DEFAULT 'True',
-  `ContributionCreated` timestamp NOT NULL DEFAULT current_timestamp(),
+  `ContributionCreated` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `ProcessTime` timestamp NULL DEFAULT NULL,
   `ProcessBy` binary(16) DEFAULT NULL,
   `LinkedProduct` binary(16) DEFAULT NULL,
   `LinkedRelease` binary(16) DEFAULT NULL,
-  `RejectionReason` text COLLATE utf8_bin DEFAULT NULL,
+  `RejectionReason` text COLLATE utf8_bin,
   PRIMARY KEY (`ContributionUUID`),
   KEY `UserUUID` (`UserUUID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 
--- Dumping data for table winworld.contributions: ~0 rows (approximately)
-/*!40000 ALTER TABLE `contributions` DISABLE KEYS */;
-/*!40000 ALTER TABLE `contributions` ENABLE KEYS */;
+-- Dumping data for table winworld.Contributions: ~0 rows (approximately)
+/*!40000 ALTER TABLE `Contributions` DISABLE KEYS */;
+/*!40000 ALTER TABLE `Contributions` ENABLE KEYS */;
 
--- Dumping structure for table winworld.downloadhits
-CREATE TABLE IF NOT EXISTS `downloadhits` (
+-- Dumping structure for table winworld.DownloadHits
+CREATE TABLE IF NOT EXISTS `DownloadHits` (
   `DownloadUUID` binary(16) NOT NULL,
   `MirrorUUID` binary(16) NOT NULL,
   `SessionUUID` binary(16) DEFAULT NULL,
   `UserUUID` binary(16) DEFAULT NULL,
   `IPAddress` varchar(46) COLLATE utf8_bin NOT NULL,
-  `DownloadTime` timestamp NOT NULL DEFAULT current_timestamp(),
+  `DownloadTime` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   KEY `DownloadUUID` (`DownloadUUID`),
   KEY `UserUUID` (`UserUUID`),
   KEY `MirrorUUID` (`MirrorUUID`),
@@ -61,12 +61,12 @@ CREATE TABLE IF NOT EXISTS `downloadhits` (
   KEY `IPAddress` (`IPAddress`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 
--- Dumping data for table winworld.downloadhits: ~0 rows (approximately)
-/*!40000 ALTER TABLE `downloadhits` DISABLE KEYS */;
-/*!40000 ALTER TABLE `downloadhits` ENABLE KEYS */;
+-- Dumping data for table winworld.DownloadHits: ~0 rows (approximately)
+/*!40000 ALTER TABLE `DownloadHits` DISABLE KEYS */;
+/*!40000 ALTER TABLE `DownloadHits` ENABLE KEYS */;
 
--- Dumping structure for table winworld.downloadmirrors
-CREATE TABLE IF NOT EXISTS `downloadmirrors` (
+-- Dumping structure for table winworld.DownloadMirrors
+CREATE TABLE IF NOT EXISTS `DownloadMirrors` (
   `MirrorUUID` binary(16) NOT NULL,
   `MirrorName` varchar(50) COLLATE utf8_bin NOT NULL,
   `Hostname` varchar(50) COLLATE utf8_bin DEFAULT NULL,
@@ -81,12 +81,12 @@ CREATE TABLE IF NOT EXISTS `downloadmirrors` (
   PRIMARY KEY (`MirrorUUID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 
--- Dumping data for table winworld.downloadmirrors: ~0 rows (approximately)
-/*!40000 ALTER TABLE `downloadmirrors` DISABLE KEYS */;
-/*!40000 ALTER TABLE `downloadmirrors` ENABLE KEYS */;
+-- Dumping data for table winworld.DownloadMirrors: ~0 rows (approximately)
+/*!40000 ALTER TABLE `DownloadMirrors` DISABLE KEYS */;
+/*!40000 ALTER TABLE `DownloadMirrors` ENABLE KEYS */;
 
--- Dumping structure for table winworld.downloads
-CREATE TABLE IF NOT EXISTS `downloads` (
+-- Dumping structure for table winworld.Downloads
+CREATE TABLE IF NOT EXISTS `Downloads` (
   `DLUUID` binary(16) NOT NULL,
   `Name` varchar(150) COLLATE utf8_bin NOT NULL,
   `Version` varchar(40) COLLATE utf8_bin NOT NULL,
@@ -95,7 +95,7 @@ CREATE TABLE IF NOT EXISTS `downloads` (
   `DownloadPath` text COLLATE utf8_bin NOT NULL,
   `ImageType` enum('Archive','35Floppy','525Floppy','CDISO','DVDISO','VPC','VMWARE','VBOX') COLLATE utf8_bin NOT NULL DEFAULT 'Archive',
   `Arch` set('x86','x86-32','m68k','ppc','amd64','mos6502','ppc64','SPARC','SPARC64','MIPS','MIPS64','Alpha','Other') COLLATE utf8_bin NOT NULL DEFAULT 'x86',
-  `Information` text COLLATE utf8_bin DEFAULT NULL,
+  `Information` text COLLATE utf8_bin,
   `ReleaseUUID` binary(16) DEFAULT NULL,
   `Upgrade` enum('True','False') COLLATE utf8_bin NOT NULL DEFAULT 'False',
   `VIPOnly` enum('True','False') COLLATE utf8_bin NOT NULL DEFAULT 'False',
@@ -103,11 +103,11 @@ CREATE TABLE IF NOT EXISTS `downloads` (
   `FileSize` bigint(20) DEFAULT NULL,
   `FileName` varchar(250) COLLATE utf8_bin DEFAULT NULL,
   `ContributionUUID` binary(16) DEFAULT NULL,
-  `CreatedDate` timestamp NULL DEFAULT current_timestamp(),
-  `LastUpdated` timestamp NULL DEFAULT current_timestamp(),
+  `CreatedDate` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  `LastUpdated` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
   `NoShowOnHome` enum('True','False') COLLATE utf8_bin NOT NULL DEFAULT 'False',
   `FileHash` varchar(255) COLLATE utf8_bin DEFAULT NULL,
-  `IPFSPath` TEXT NULL DEFAULT NULL COLLATE 'utf8_bin',
+  `IPFSPath` text COLLATE utf8_bin,
   PRIMARY KEY (`DLUUID`),
   KEY `ReleaseUUID` (`ReleaseUUID`),
   KEY `FileName` (`Name`),
@@ -118,23 +118,23 @@ CREATE TABLE IF NOT EXISTS `downloads` (
   FULLTEXT KEY `Information` (`Information`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 
--- Dumping data for table winworld.downloads: ~0 rows (approximately)
-/*!40000 ALTER TABLE `downloads` DISABLE KEYS */;
-/*!40000 ALTER TABLE `downloads` ENABLE KEYS */;
+-- Dumping data for table winworld.Downloads: ~0 rows (approximately)
+/*!40000 ALTER TABLE `Downloads` DISABLE KEYS */;
+/*!40000 ALTER TABLE `Downloads` ENABLE KEYS */;
 
--- Dumping structure for table winworld.mirrorcontents
-CREATE TABLE IF NOT EXISTS `mirrorcontents` (
+-- Dumping structure for table winworld.MirrorContents
+CREATE TABLE IF NOT EXISTS `MirrorContents` (
   `MirrorUUID` binary(16) DEFAULT NULL,
   `DownloadUUID` binary(16) DEFAULT NULL,
   KEY `UUIDS` (`MirrorUUID`,`DownloadUUID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 
--- Dumping data for table winworld.mirrorcontents: ~0 rows (approximately)
-/*!40000 ALTER TABLE `mirrorcontents` DISABLE KEYS */;
-/*!40000 ALTER TABLE `mirrorcontents` ENABLE KEYS */;
+-- Dumping data for table winworld.MirrorContents: ~0 rows (approximately)
+/*!40000 ALTER TABLE `MirrorContents` DISABLE KEYS */;
+/*!40000 ALTER TABLE `MirrorContents` ENABLE KEYS */;
 
--- Dumping structure for table winworld.products
-CREATE TABLE IF NOT EXISTS `products` (
+-- Dumping structure for table winworld.Products
+CREATE TABLE IF NOT EXISTS `Products` (
   `ProductUUID` binary(16) NOT NULL,
   `DiscussionUUID` binary(16) NOT NULL,
   `Name` varchar(150) NOT NULL,
@@ -142,7 +142,7 @@ CREATE TABLE IF NOT EXISTS `products` (
   `Notes` text NOT NULL,
   `LogoImage` varchar(150) DEFAULT NULL,
   `Type` enum('OS','Game','Application','DevTool','System') NOT NULL DEFAULT 'Application',
-  `ProductCreated` timestamp NULL DEFAULT current_timestamp(),
+  `ProductCreated` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
   `DefaultRelease` binary(16) DEFAULT NULL,
   `ApplicationTags` set('Word Processor','Spreadsheet','Presentations','Web Browser','Chat','Utility','Graphics','Publishing','Financial','Reference','Editor','Communications','Novelty','PIM','Video','Audio','Document','Media Player','Virtualization','Archive','Other','Server','Database','Mathematics','Planning','Education','Engineering') DEFAULT NULL,
   PRIMARY KEY (`ProductUUID`),
@@ -156,18 +156,18 @@ CREATE TABLE IF NOT EXISTS `products` (
   FULLTEXT KEY `Name` (`Name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table winworld.products: ~0 rows (approximately)
-/*!40000 ALTER TABLE `products` DISABLE KEYS */;
-/*!40000 ALTER TABLE `products` ENABLE KEYS */;
+-- Dumping data for table winworld.Products: ~0 rows (approximately)
+/*!40000 ALTER TABLE `Products` DISABLE KEYS */;
+/*!40000 ALTER TABLE `Products` ENABLE KEYS */;
 
--- Dumping structure for table winworld.releases
-CREATE TABLE IF NOT EXISTS `releases` (
+-- Dumping structure for table winworld.Releases
+CREATE TABLE IF NOT EXISTS `Releases` (
   `ReleaseUUID` binary(16) NOT NULL,
   `ProductUUID` binary(16) NOT NULL,
   `Name` varchar(50) CHARACTER SET utf8 NOT NULL,
   `VendorName` varchar(50) CHARACTER SET utf8 DEFAULT NULL,
   `Slug` varchar(100) COLLATE utf8_bin DEFAULT NULL,
-  `ReleaseOrder` int(11) NOT NULL DEFAULT 0,
+  `ReleaseOrder` int(11) NOT NULL DEFAULT '0',
   `ReleaseDate` timestamp NULL DEFAULT NULL,
   `EndOfLife` timestamp NULL DEFAULT NULL,
   `FuzzyDate` enum('True','False') COLLATE utf8_bin NOT NULL DEFAULT 'False',
@@ -179,8 +179,8 @@ CREATE TABLE IF NOT EXISTS `releases` (
   `Networking` varchar(300) COLLATE utf8_bin DEFAULT NULL,
   `Type` enum('GUI','Text') COLLATE utf8_bin NOT NULL DEFAULT 'GUI',
   `SerialRequired` enum('True','False') COLLATE utf8_bin NOT NULL DEFAULT 'False',
-  `InstallInstructions` longtext CHARACTER SET utf8 DEFAULT NULL,
-  `Notes` longtext CHARACTER SET utf8 DEFAULT NULL,
+  `InstallInstructions` longtext CHARACTER SET utf8,
+  `Notes` longtext CHARACTER SET utf8,
   `Platform` set('DOS','CPM','Windows','OS2','Unix','Linux','MacOS','Mac OS X','DOSShell','Other') COLLATE utf8_bin DEFAULT NULL,
   `DefaultDownload` binary(16) DEFAULT NULL,
   PRIMARY KEY (`ReleaseUUID`),
@@ -193,12 +193,12 @@ CREATE TABLE IF NOT EXISTS `releases` (
   FULLTEXT KEY `Name_VendorName_InstallInstructions_Notes` (`InstallInstructions`,`Notes`,`Name`,`VendorName`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 
--- Dumping data for table winworld.releases: ~0 rows (approximately)
-/*!40000 ALTER TABLE `releases` DISABLE KEYS */;
-/*!40000 ALTER TABLE `releases` ENABLE KEYS */;
+-- Dumping data for table winworld.Releases: ~0 rows (approximately)
+/*!40000 ALTER TABLE `Releases` DISABLE KEYS */;
+/*!40000 ALTER TABLE `Releases` ENABLE KEYS */;
 
--- Dumping structure for table winworld.screenshots
-CREATE TABLE IF NOT EXISTS `screenshots` (
+-- Dumping structure for table winworld.Screenshots
+CREATE TABLE IF NOT EXISTS `Screenshots` (
   `ScreenshotUUID` binary(16) NOT NULL,
   `ReleaseUUID` binary(16) DEFAULT NULL,
   `ScreenshotTitle` varchar(750) COLLATE utf8_bin DEFAULT NULL,
@@ -207,38 +207,40 @@ CREATE TABLE IF NOT EXISTS `screenshots` (
   KEY `ReleaseUUID` (`ReleaseUUID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 
--- Dumping data for table winworld.screenshots: ~0 rows (approximately)
-/*!40000 ALTER TABLE `screenshots` DISABLE KEYS */;
-/*!40000 ALTER TABLE `screenshots` ENABLE KEYS */;
+-- Dumping data for table winworld.Screenshots: ~0 rows (approximately)
+/*!40000 ALTER TABLE `Screenshots` DISABLE KEYS */;
+/*!40000 ALTER TABLE `Screenshots` ENABLE KEYS */;
 
--- Dumping structure for table winworld.serials
-CREATE TABLE IF NOT EXISTS `serials` (
+-- Dumping structure for table winworld.Serials
+CREATE TABLE IF NOT EXISTS `Serials` (
   `ReleaseUUID` binary(16) DEFAULT NULL,
   `Serial` varchar(500) COLLATE utf8_bin DEFAULT NULL,
   KEY `ReleaseUUID` (`ReleaseUUID`) USING HASH
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 
--- Dumping data for table winworld.serials: ~0 rows (approximately)
-/*!40000 ALTER TABLE `serials` DISABLE KEYS */;
-/*!40000 ALTER TABLE `serials` ENABLE KEYS */;
+-- Dumping data for table winworld.Serials: ~0 rows (approximately)
+/*!40000 ALTER TABLE `Serials` DISABLE KEYS */;
+/*!40000 ALTER TABLE `Serials` ENABLE KEYS */;
 
--- Dumping structure for table winworld.userflagholders
-CREATE TABLE IF NOT EXISTS `userflagholders` (
+-- Dumping structure for table winworld.UserFlagHolders
+CREATE TABLE IF NOT EXISTS `UserFlagHolders` (
   `FlagUUID` binary(16) NOT NULL,
   `UserUUID` binary(16) NOT NULL,
-  `Added` timestamp NOT NULL DEFAULT current_timestamp(),
+  `Added` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   KEY `GroupUUID` (`FlagUUID`),
   KEY `UserUUID` (`UserUUID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 
--- Dumping data for table winworld.userflagholders: ~1 rows (approximately)
-/*!40000 ALTER TABLE `userflagholders` DISABLE KEYS */;
-INSERT IGNORE INTO `userflagholders` (`FlagUUID`, `UserUUID`, `Added`) VALUES
-	(_binary 0x25C5A043C3867BC2B311C3A4C29D7100, _binary 0x7B05DE4D3F2111E88D2AFA163E9022F0, '2017-08-02 04:26:41');
-/*!40000 ALTER TABLE `userflagholders` ENABLE KEYS */;
+-- Dumping data for table winworld.UserFlagHolders: ~2 rows (approximately)
+/*!40000 ALTER TABLE `UserFlagHolders` DISABLE KEYS */;
+INSERT IGNORE INTO `UserFlagHolders` (`FlagUUID`, `UserUUID`, `Added`) VALUES
+	(_binary 0x557074696D6500006500630074006500, _binary 0x000000000000000000000000205CA002, '2017-08-02 04:26:41'),
+	(_binary 0x25C5A043C3867BC2B311C3A4C29D7100, _binary 0x7B05DE4D3F2111E88D2AFA163E9022F0, '2017-08-02 04:26:41'),
+	(_binary 0x11E99BFCD1E51F4C853FE86A64A6C64B, _binary 0x11E99C2A69150375A00AE86A64A6C64B, '2019-07-01 20:05:16');
+/*!40000 ALTER TABLE `UserFlagHolders` ENABLE KEYS */;
 
--- Dumping structure for table winworld.userflags
-CREATE TABLE IF NOT EXISTS `userflags` (
+-- Dumping structure for table winworld.UserFlags
+CREATE TABLE IF NOT EXISTS `UserFlags` (
   `FlagUUID` binary(16) NOT NULL,
   `FlagName` varchar(15) NOT NULL,
   `LongName` varchar(250) NOT NULL,
@@ -250,48 +252,48 @@ CREATE TABLE IF NOT EXISTS `userflags` (
   UNIQUE KEY `FlagName` (`FlagName`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table winworld.userflags: ~0 rows (approximately)
-/*!40000 ALTER TABLE `userflags` DISABLE KEYS */;
-INSERT IGNORE INTO `userflags` (`FlagUUID`, `FlagName`, `LongName`, `SystemFlag`, `Preemptive`, `PublicVisible`, `FlagColour`) VALUES
+-- Dumping data for table winworld.UserFlags: ~2 rows (approximately)
+/*!40000 ALTER TABLE `UserFlags` DISABLE KEYS */;
+INSERT IGNORE INTO `UserFlags` (`FlagUUID`, `FlagName`, `LongName`, `SystemFlag`, `Preemptive`, `PublicVisible`, `FlagColour`) VALUES
 	(_binary 0x11E99BFCD1E51F4C853FE86A64A6C64B, 'sa', 'Site Admin', 'True', 'False', 'True', 'primary'),
 	(_binary 0x11E99BFCD1E77AC6853FE86A64A6C64B, 'vip', 'VIP Member', 'False', 'False', 'True', 'success');
-/*!40000 ALTER TABLE `userflags` ENABLE KEYS */;
+/*!40000 ALTER TABLE `UserFlags` ENABLE KEYS */;
 
--- Dumping structure for table winworld.userrecoverpasswordrequests
-CREATE TABLE IF NOT EXISTS `userrecoverpasswordrequests` (
+-- Dumping structure for table winworld.UserRecoverPasswordRequests
+CREATE TABLE IF NOT EXISTS `UserRecoverPasswordRequests` (
   `RequestID` binary(16) NOT NULL,
   `UserID` binary(16) NOT NULL,
-  `DateCreated` timestamp NOT NULL DEFAULT current_timestamp(),
+  `DateCreated` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`RequestID`),
   UNIQUE KEY `UserID` (`UserID`),
   UNIQUE KEY `RequestID` (`RequestID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
--- Dumping data for table winworld.userrecoverpasswordrequests: ~0 rows (approximately)
-/*!40000 ALTER TABLE `userrecoverpasswordrequests` DISABLE KEYS */;
-/*!40000 ALTER TABLE `userrecoverpasswordrequests` ENABLE KEYS */;
+-- Dumping data for table winworld.UserRecoverPasswordRequests: ~0 rows (approximately)
+/*!40000 ALTER TABLE `UserRecoverPasswordRequests` DISABLE KEYS */;
+/*!40000 ALTER TABLE `UserRecoverPasswordRequests` ENABLE KEYS */;
 
--- Dumping structure for table winworld.users
-CREATE TABLE IF NOT EXISTS `users` (
+-- Dumping structure for table winworld.Users
+CREATE TABLE IF NOT EXISTS `Users` (
   `UserID` binary(16) NOT NULL,
   `Email` varchar(80) COLLATE utf8_unicode_ci NOT NULL,
   `AccountEnabled` enum('True','False') COLLATE utf8_unicode_ci NOT NULL DEFAULT 'True',
   `Password` varchar(64) COLLATE utf8_unicode_ci NOT NULL,
   `Salt` varchar(64) COLLATE utf8_unicode_ci DEFAULT NULL,
   `ShortName` varchar(64) COLLATE utf8_unicode_ci DEFAULT NULL,
-  `RegistrationTime` timestamp NOT NULL DEFAULT current_timestamp(),
-  `LastSeenTime` timestamp NOT NULL DEFAULT current_timestamp(),
+  `RegistrationTime` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `LastSeenTime` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `RegistrationIP` varchar(45) COLLATE utf8_unicode_ci NOT NULL,
   `ThemeName` varchar(50) COLLATE utf8_unicode_ci NOT NULL DEFAULT 'default',
   PRIMARY KEY (`UserID`),
   UNIQUE KEY `UniqueVals` (`ShortName`,`Email`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
--- Dumping data for table winworld.users: ~0 rows (approximately)
-/*!40000 ALTER TABLE `users` DISABLE KEYS */;
-INSERT IGNORE INTO `users` (`UserID`, `Email`, `AccountEnabled`, `Password`, `Salt`, `ShortName`, `RegistrationTime`, `LastSeenTime`, `RegistrationIP`, `ThemeName`) VALUES
+-- Dumping data for table winworld.Users: ~0 rows (approximately)
+/*!40000 ALTER TABLE `Users` DISABLE KEYS */;
+INSERT IGNORE INTO `Users` (`UserID`, `Email`, `AccountEnabled`, `Password`, `Salt`, `ShortName`, `RegistrationTime`, `LastSeenTime`, `RegistrationIP`, `ThemeName`) VALUES
 	(_binary 0x11E99BFCD1E9E3F7853FE86A64A6C64B, 'root@localhost', 'True', '$2a$12$I7Z0lrQFyxgRFgWVB8FX1.FYpJDEN7Z5x4Mp4a7I8bT26G3OU8USa', '', 'admin', '2019-07-01 14:36:16', '2018-04-07 00:27:28', '', 'default');
-/*!40000 ALTER TABLE `users` ENABLE KEYS */;
+/*!40000 ALTER TABLE `Users` ENABLE KEYS */;
 
 -- Dumping structure for function winworld.UUIDBIN
 DELIMITER //
@@ -310,7 +312,7 @@ DELIMITER ;
 -- Dumping structure for trigger winworld.BeforeCreateContribution
 SET @OLDTMP_SQL_MODE=@@SQL_MODE, SQL_MODE='STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION';
 DELIMITER //
-CREATE TRIGGER `BeforeCreateContribution` BEFORE INSERT ON `contributions` FOR EACH ROW BEGIN
+CREATE TRIGGER `BeforeCreateContribution` BEFORE INSERT ON `Contributions` FOR EACH ROW BEGIN
 SET NEW.ContributionUUID = UUIDBIN(UUID());
 END//
 DELIMITER ;
@@ -319,7 +321,7 @@ SET SQL_MODE=@OLDTMP_SQL_MODE;
 -- Dumping structure for trigger winworld.BeforeCreateDownload
 SET @OLDTMP_SQL_MODE=@@SQL_MODE, SQL_MODE='STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION';
 DELIMITER //
-CREATE TRIGGER `BeforeCreateDownload` BEFORE INSERT ON `downloads` FOR EACH ROW BEGIN
+CREATE TRIGGER `BeforeCreateDownload` BEFORE INSERT ON `Downloads` FOR EACH ROW BEGIN
 SET New.DLUUID = UUIDBIN(UUID());
 END//
 DELIMITER ;
@@ -328,7 +330,7 @@ SET SQL_MODE=@OLDTMP_SQL_MODE;
 -- Dumping structure for trigger winworld.BeforeCreateFlags
 SET @OLDTMP_SQL_MODE=@@SQL_MODE, SQL_MODE='STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION';
 DELIMITER //
-CREATE TRIGGER `BeforeCreateFlags` BEFORE INSERT ON `userflags` FOR EACH ROW BEGIN
+CREATE TRIGGER `BeforeCreateFlags` BEFORE INSERT ON `UserFlags` FOR EACH ROW BEGIN
 SET NEW.FlagUUID = UUIDBIN(UUID());
 END//
 DELIMITER ;
@@ -337,7 +339,7 @@ SET SQL_MODE=@OLDTMP_SQL_MODE;
 -- Dumping structure for trigger winworld.BeforeCreateMirror
 SET @OLDTMP_SQL_MODE=@@SQL_MODE, SQL_MODE='STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION';
 DELIMITER //
-CREATE TRIGGER `BeforeCreateMirror` BEFORE INSERT ON `downloadmirrors` FOR EACH ROW BEGIN
+CREATE TRIGGER `BeforeCreateMirror` BEFORE INSERT ON `DownloadMirrors` FOR EACH ROW BEGIN
 SET NEW.MirrorUUID = UUIDBIN(UUID());
 END//
 DELIMITER ;
@@ -346,7 +348,7 @@ SET SQL_MODE=@OLDTMP_SQL_MODE;
 -- Dumping structure for trigger winworld.BeforeCreateProduct
 SET @OLDTMP_SQL_MODE=@@SQL_MODE, SQL_MODE='STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION';
 DELIMITER //
-CREATE TRIGGER `BeforeCreateProduct` BEFORE INSERT ON `products` FOR EACH ROW BEGIN
+CREATE TRIGGER `BeforeCreateProduct` BEFORE INSERT ON `Products` FOR EACH ROW BEGIN
 SET NEW.ProductUUID = UUIDBIN(UUID());
 END//
 DELIMITER ;
@@ -355,7 +357,7 @@ SET SQL_MODE=@OLDTMP_SQL_MODE;
 -- Dumping structure for trigger winworld.BeforeCreateRecoverPassword
 SET @OLDTMP_SQL_MODE=@@SQL_MODE, SQL_MODE='STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION';
 DELIMITER //
-CREATE TRIGGER `BeforeCreateRecoverPassword` BEFORE INSERT ON `userrecoverpasswordrequests` FOR EACH ROW BEGIN
+CREATE TRIGGER `BeforeCreateRecoverPassword` BEFORE INSERT ON `UserRecoverPasswordRequests` FOR EACH ROW BEGIN
 	SET NEW.RequestID = UUIDBIN(UUID());
 	SET NEW.DateCreated = NOW();
 END//
@@ -365,7 +367,7 @@ SET SQL_MODE=@OLDTMP_SQL_MODE;
 -- Dumping structure for trigger winworld.BeforeCreateRelease
 SET @OLDTMP_SQL_MODE=@@SQL_MODE, SQL_MODE='STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION';
 DELIMITER //
-CREATE TRIGGER `BeforeCreateRelease` BEFORE INSERT ON `releases` FOR EACH ROW BEGIN
+CREATE TRIGGER `BeforeCreateRelease` BEFORE INSERT ON `Releases` FOR EACH ROW BEGIN
 SET NEW.ReleaseUUID = UUIDBIN(UUID());
 END//
 DELIMITER ;
@@ -374,7 +376,7 @@ SET SQL_MODE=@OLDTMP_SQL_MODE;
 -- Dumping structure for trigger winworld.BeforeCreateScreenshot
 SET @OLDTMP_SQL_MODE=@@SQL_MODE, SQL_MODE='STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION';
 DELIMITER //
-CREATE TRIGGER `BeforeCreateScreenshot` BEFORE INSERT ON `screenshots` FOR EACH ROW BEGIN
+CREATE TRIGGER `BeforeCreateScreenshot` BEFORE INSERT ON `Screenshots` FOR EACH ROW BEGIN
 SET NEW.ScreenshotUUID = UUIDBIN(UUID());
 END//
 DELIMITER ;
@@ -383,7 +385,7 @@ SET SQL_MODE=@OLDTMP_SQL_MODE;
 -- Dumping structure for trigger winworld.BeforeCreateUser
 SET @OLDTMP_SQL_MODE=@@SQL_MODE, SQL_MODE='STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION';
 DELIMITER //
-CREATE TRIGGER `BeforeCreateUser` BEFORE INSERT ON `users` FOR EACH ROW BEGIN
+CREATE TRIGGER `BeforeCreateUser` BEFORE INSERT ON `Users` FOR EACH ROW BEGIN
 	SET NEW.UserID = UUIDBIN(UUID());
 	SET NEW.RegistrationTime = NOW();
 END//

--- a/adventure/deploy/install.sql
+++ b/adventure/deploy/install.sql
@@ -1,324 +1,394 @@
-﻿-- Adventure database install script
+-- --------------------------------------------------------
+-- Host:                         127.0.0.1
+-- Server version:               10.4.6-MariaDB - mariadb.org binary distribution
+-- Server OS:                    Win64
+-- HeidiSQL Version:             9.5.0.5196
+-- --------------------------------------------------------
 
--- These tables contain site contents.
--- Any sets in a column must match what's in your "config.json."
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET NAMES utf8 */;
+/*!50503 SET NAMES utf8mb4 */;
+/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
+/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
 
-CREATE TABLE `Contributions` (
-	`ContributionUUID` BINARY(16) NOT NULL,
-	`UserUUID` BINARY(16) NOT NULL,
-	`ProductTitle` VARCHAR(100) NOT NULL COLLATE 'utf8_bin',
-	`ReleaseTitle` VARCHAR(50) NOT NULL COLLATE 'utf8_bin',
-	`VendorName` VARCHAR(50) NULL DEFAULT NULL COLLATE 'utf8_bin',
-	`ReleaseDate` TIMESTAMP NULL DEFAULT NULL,
-	`EOLDate` TIMESTAMP NULL DEFAULT NULL,
-	`Platform` SET('DOS','CPM','Windows','OS2','Unix','Linux','MacOS','Mac OS X','DOSShell','Other') NULL DEFAULT NULL COLLATE 'utf8_bin',
-	`Arch` SET('x86','x86-32','m68k','ppc','amd64','mos6502','ppc64','SPARC','SPARC64','MIPS','MIPS64','Alpha','Other') NULL DEFAULT NULL COLLATE 'utf8_bin',
-	`CPURequirement` VARCHAR(150) NULL DEFAULT NULL COLLATE 'utf8_bin',
-	`RAMRequirement` INT(10) UNSIGNED NULL DEFAULT NULL,
-	`DiskRequirement` INT(10) UNSIGNED NULL DEFAULT NULL,
-	`AboutRelease` TEXT NULL DEFAULT NULL COLLATE 'utf8_bin',
-	`InstallInstructions` TEXT NULL DEFAULT NULL COLLATE 'utf8_bin',
-	`FTPUser` VARCHAR(50) NULL DEFAULT NULL COLLATE 'utf8_bin',
-	`FTPPassword` VARCHAR(350) NULL DEFAULT NULL COLLATE 'utf8_bin',
-	`FTPUploadDirectory` VARCHAR(350) NULL DEFAULT NULL COLLATE 'utf8_bin',
-	`Status` ENUM('New','Uploaded','Processing','Public','Verified','Rejected') NOT NULL DEFAULT 'New' COLLATE 'utf8_bin',
-	`FTPAccountEnabled` SET('True','False') NOT NULL DEFAULT 'True' COLLATE 'utf8_bin',
-	`ContributionCreated` TIMESTAMP NOT NULL DEFAULT '',
-	`ProcessTime` TIMESTAMP NULL DEFAULT NULL,
-	`ProcessBy` BINARY(16) NULL DEFAULT NULL,
-	`LinkedProduct` BINARY(16) NULL DEFAULT NULL,
-	`LinkedRelease` BINARY(16) NULL DEFAULT NULL,
-	`RejectionReason` TEXT NULL DEFAULT NULL COLLATE 'utf8_bin',
-	PRIMARY KEY (`ContributionUUID`),
-	INDEX `UserUUID` (`UserUUID`)
-)
-COLLATE='utf8_bin'
-ENGINE=Aria
-;
+-- Dumping structure for table winworld.contributions
+CREATE TABLE IF NOT EXISTS `contributions` (
+  `ContributionUUID` binary(16) NOT NULL,
+  `UserUUID` binary(16) NOT NULL,
+  `ProductTitle` varchar(100) COLLATE utf8_bin NOT NULL,
+  `ReleaseTitle` varchar(50) COLLATE utf8_bin NOT NULL,
+  `VendorName` varchar(50) COLLATE utf8_bin DEFAULT NULL,
+  `ReleaseDate` timestamp NULL DEFAULT NULL,
+  `EOLDate` timestamp NULL DEFAULT NULL,
+  `Platform` set('DOS','CPM','Windows','OS2','Unix','Linux','MacOS','Mac OS X','DOSShell','Other') COLLATE utf8_bin DEFAULT NULL,
+  `Arch` set('x86','x86-32','m68k','ppc','amd64','mos6502','ppc64','SPARC','SPARC64','MIPS','MIPS64','Alpha','Other') COLLATE utf8_bin DEFAULT NULL,
+  `CPURequirement` varchar(150) COLLATE utf8_bin DEFAULT NULL,
+  `RAMRequirement` int(10) unsigned DEFAULT NULL,
+  `DiskRequirement` int(10) unsigned DEFAULT NULL,
+  `AboutRelease` text COLLATE utf8_bin DEFAULT NULL,
+  `InstallInstructions` text COLLATE utf8_bin DEFAULT NULL,
+  `FTPUser` varchar(50) COLLATE utf8_bin DEFAULT NULL,
+  `FTPPassword` varchar(350) COLLATE utf8_bin DEFAULT NULL,
+  `FTPUploadDirectory` varchar(350) COLLATE utf8_bin DEFAULT NULL,
+  `Status` enum('New','Uploaded','Processing','Public','Verified','Rejected') COLLATE utf8_bin NOT NULL DEFAULT 'New',
+  `FTPAccountEnabled` set('True','False') COLLATE utf8_bin NOT NULL DEFAULT 'True',
+  `ContributionCreated` timestamp NOT NULL DEFAULT current_timestamp(),
+  `ProcessTime` timestamp NULL DEFAULT NULL,
+  `ProcessBy` binary(16) DEFAULT NULL,
+  `LinkedProduct` binary(16) DEFAULT NULL,
+  `LinkedRelease` binary(16) DEFAULT NULL,
+  `RejectionReason` text COLLATE utf8_bin DEFAULT NULL,
+  PRIMARY KEY (`ContributionUUID`),
+  KEY `UserUUID` (`UserUUID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 
-CREATE TABLE `DownloadHits` (
-	`DownloadUUID` BINARY(16) NOT NULL,
-	`MirrorUUID` BINARY(16) NOT NULL,
-	`SessionUUID` BINARY(16) NULL DEFAULT NULL,
-	`UserUUID` BINARY(16) NULL DEFAULT NULL,
-	`IPAddress` VARCHAR(46) NOT NULL COLLATE 'utf8_bin',
-	`DownloadTime` TIMESTAMP NOT NULL DEFAULT '',
-	INDEX `DownloadUUID` (`DownloadUUID`),
-	INDEX `UserUUID` (`UserUUID`),
-	INDEX `MirrorUUID` (`MirrorUUID`),
-	INDEX `DownloadTime` (`DownloadTime`),
-	INDEX `IPAddress` (`IPAddress`)
-)
-COLLATE='utf8_bin'
-ENGINE=Aria
-;
+-- Dumping data for table winworld.contributions: ~0 rows (approximately)
+/*!40000 ALTER TABLE `contributions` DISABLE KEYS */;
+/*!40000 ALTER TABLE `contributions` ENABLE KEYS */;
 
-CREATE TABLE `DownloadMirrors` (
-	`MirrorUUID` BINARY(16) NOT NULL,
-	`MirrorName` VARCHAR(50) NOT NULL COLLATE 'utf8_bin',
-	`Hostname` VARCHAR(50) NULL DEFAULT NULL COLLATE 'utf8_bin',
-	`IsOnline` ENUM('True','False') NULL DEFAULT 'True' COLLATE 'utf8_bin',
-	`Location` VARCHAR(50) NULL DEFAULT NULL COLLATE 'utf8_bin',
-	`UnixUser` VARCHAR(20) NULL DEFAULT NULL COLLATE 'utf8_bin',
-	`HomeDirectory` VARCHAR(150) NULL DEFAULT NULL COLLATE 'utf8_bin',
-	`DownloadDirectory` VARCHAR(150) NULL DEFAULT NULL COLLATE 'utf8_bin',
-	`Country` ENUM('FR','UK','US','JP','EU','CA') NULL DEFAULT NULL COLLATE 'utf8_bin',
-	`Webserver` ENUM('True','False') NOT NULL DEFAULT 'False' COLLATE 'utf8_bin',
-	`SSHFingerprint` VARBINARY(100) NULL DEFAULT NULL,
-	PRIMARY KEY (`MirrorUUID`)
-)
-COLLATE='utf8_bin'
-ENGINE=Aria
-;
+-- Dumping structure for table winworld.downloadhits
+CREATE TABLE IF NOT EXISTS `downloadhits` (
+  `DownloadUUID` binary(16) NOT NULL,
+  `MirrorUUID` binary(16) NOT NULL,
+  `SessionUUID` binary(16) DEFAULT NULL,
+  `UserUUID` binary(16) DEFAULT NULL,
+  `IPAddress` varchar(46) COLLATE utf8_bin NOT NULL,
+  `DownloadTime` timestamp NOT NULL DEFAULT current_timestamp(),
+  KEY `DownloadUUID` (`DownloadUUID`),
+  KEY `UserUUID` (`UserUUID`),
+  KEY `MirrorUUID` (`MirrorUUID`),
+  KEY `DownloadTime` (`DownloadTime`),
+  KEY `IPAddress` (`IPAddress`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 
-CREATE TABLE `Downloads` (
-	`DLUUID` BINARY(16) NOT NULL,
-	`Name` VARCHAR(150) NOT NULL COLLATE 'utf8_bin',
-	`Version` VARCHAR(40) NOT NULL COLLATE 'utf8_bin',
-	`RTM` ENUM('True','False') NOT NULL DEFAULT 'True' COLLATE 'utf8_bin',
-	`OriginalPath` TEXT NOT NULL COLLATE 'utf8_bin',
-	`DownloadPath` TEXT NOT NULL COLLATE 'utf8_bin',
-	`ImageType` ENUM('Archive','35Floppy','525Floppy','CDISO','DVDISO','VPC','VMWARE','VBOX') NOT NULL DEFAULT 'Archive' COLLATE 'utf8_bin',
-	`Arch` SET('x86','x86-32','m68k','ppc','amd64','mos6502','ppc64','SPARC','SPARC64','MIPS','MIPS64','Alpha','Other') NOT NULL DEFAULT 'x86' COLLATE 'utf8_bin',
-	`Information` TEXT NULL DEFAULT NULL COLLATE 'utf8_bin',
-	`ReleaseUUID` BINARY(16) NULL DEFAULT NULL,
-	`Upgrade` ENUM('True','False') NOT NULL DEFAULT 'False' COLLATE 'utf8_bin',
-	`VIPOnly` ENUM('True','False') NOT NULL DEFAULT 'False' COLLATE 'utf8_bin',
-	`Language` VARCHAR(50) NOT NULL DEFAULT 'English' COLLATE 'utf8_bin',
-	`FileSize` BIGINT(20) NULL DEFAULT NULL,
-	`FileName` VARCHAR(250) NULL DEFAULT NULL COLLATE 'utf8_bin',
-	`ContributionUUID` BINARY(16) NULL DEFAULT NULL,
-	`CreatedDate` TIMESTAMP NULL DEFAULT '',
-	`LastUpdated` TIMESTAMP NULL DEFAULT '',
-	`NoShowOnHome` ENUM('True','False') NOT NULL DEFAULT 'False' COLLATE 'utf8_bin',
-	`FileHash` VARCHAR(255) NULL DEFAULT NULL COLLATE 'utf8_bin',
-	PRIMARY KEY (`DLUUID`),
-	INDEX `ReleaseUUID` (`ReleaseUUID`),
-	INDEX `FileName` (`Name`),
-	INDEX `ContributionUUID` (`ContributionUUID`),
-	INDEX `NoShowOnHome` (`NoShowOnHome`),
-	INDEX `CreatedDate` (`CreatedDate`),
-	INDEX `LastUpdated` (`LastUpdated`),
-	FULLTEXT INDEX `Information` (`Information`)
-)
-COLLATE='utf8_bin'
-ENGINE=Aria
-;
+-- Dumping data for table winworld.downloadhits: ~0 rows (approximately)
+/*!40000 ALTER TABLE `downloadhits` DISABLE KEYS */;
+/*!40000 ALTER TABLE `downloadhits` ENABLE KEYS */;
 
-CREATE TABLE `MirrorContents` (
-	`MirrorUUID` BINARY(16) NULL DEFAULT NULL,
-	`DownloadUUID` BINARY(16) NULL DEFAULT NULL,
-	INDEX `UUIDS` (`MirrorUUID`, `DownloadUUID`)
-)
-COLLATE='utf8_bin'
-ENGINE=Aria
-;
+-- Dumping structure for table winworld.downloadmirrors
+CREATE TABLE IF NOT EXISTS `downloadmirrors` (
+  `MirrorUUID` binary(16) NOT NULL,
+  `MirrorName` varchar(50) COLLATE utf8_bin NOT NULL,
+  `Hostname` varchar(50) COLLATE utf8_bin DEFAULT NULL,
+  `IsOnline` enum('True','False') COLLATE utf8_bin DEFAULT 'True',
+  `Location` varchar(50) COLLATE utf8_bin DEFAULT NULL,
+  `UnixUser` varchar(20) COLLATE utf8_bin DEFAULT NULL,
+  `HomeDirectory` varchar(150) COLLATE utf8_bin DEFAULT NULL,
+  `DownloadDirectory` varchar(150) COLLATE utf8_bin DEFAULT NULL,
+  `Country` enum('FR','UK','US','JP','EU','CA') COLLATE utf8_bin DEFAULT NULL,
+  `Webserver` enum('True','False') COLLATE utf8_bin NOT NULL DEFAULT 'False',
+  `SSHFingerprint` varbinary(100) DEFAULT NULL,
+  PRIMARY KEY (`MirrorUUID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 
-CREATE TABLE `Products` (
-	`ProductUUID` BINARY(16) NOT NULL,
-	`DiscussionUUID` BINARY(16) NOT NULL,
-	`Name` VARCHAR(150) NOT NULL,
-	`Slug` VARCHAR(100) NULL DEFAULT NULL,
-	`Notes` TEXT NOT NULL,
-	`LogoImage` VARCHAR(150) NULL DEFAULT NULL,
-	`Type` ENUM('OS','Game','Application','DevTool','System') NOT NULL DEFAULT 'Application',
-	`ProductCreated` TIMESTAMP NULL DEFAULT '',
-	`DefaultRelease` BINARY(16) NULL DEFAULT NULL,
-	`ApplicationTags` SET('Word Processor','Spreadsheet','Presentations','Web Browser','Chat','Utility','Graphics','Publishing','Financial','Reference','Editor','Communications','Novelty','PIM','Video','Audio','Document','Media Player','Virtualization','Archive','Other','Server','Database','Mathematics','Planning','Education','Engineering') NULL DEFAULT NULL,
-	PRIMARY KEY (`ProductUUID`),
-	INDEX `Name_Slug` (`Name`, `Slug`),
-	INDEX `Type_Platform` (`Type`),
-	INDEX `DefaultRelease` (`DefaultRelease`),
-	INDEX `ApplicationTags` (`ApplicationTags`),
-	INDEX `DiscussionUUID` (`DiscussionUUID`),
-	FULLTEXT INDEX `Notes` (`Notes`),
-	FULLTEXT INDEX `Name_Notes` (`Name`, `Notes`),
-	FULLTEXT INDEX `Name` (`Name`)
-)
-COLLATE='utf8_general_ci'
-ENGINE=Aria
-;
+-- Dumping data for table winworld.downloadmirrors: ~0 rows (approximately)
+/*!40000 ALTER TABLE `downloadmirrors` DISABLE KEYS */;
+/*!40000 ALTER TABLE `downloadmirrors` ENABLE KEYS */;
 
-CREATE TABLE `Releases` (
-	`ReleaseUUID` BINARY(16) NOT NULL,
-	`ProductUUID` BINARY(16) NOT NULL,
-	`Name` VARCHAR(50) NOT NULL COLLATE 'utf8_general_ci',
-	`VendorName` VARCHAR(50) NULL DEFAULT NULL COLLATE 'utf8_general_ci',
-	`Slug` VARCHAR(100) NULL DEFAULT NULL COLLATE 'utf8_bin',
-	`ReleaseOrder` INT(11) NOT NULL DEFAULT '0',
-	`ReleaseDate` TIMESTAMP NULL DEFAULT NULL,
-	`EndOfLife` TIMESTAMP NULL DEFAULT NULL,
-	`FuzzyDate` ENUM('True','False') NOT NULL DEFAULT 'False' COLLATE 'utf8_bin',
-	`Arch` SET('x86','x86-32','m68k','ppc','amd64','mos6502','ppc64','SPARC','SPARC64','MIPS','MIPS64','Alpha','Other') NULL DEFAULT NULL COLLATE 'utf8_bin',
-	`RAMRequirement` INT(10) UNSIGNED NULL DEFAULT NULL COMMENT 'in bytes',
-	`CPURequirement` VARCHAR(50) NULL DEFAULT NULL COLLATE 'utf8_bin',
-	`DiskSpaceRequired` INT(10) UNSIGNED NULL DEFAULT NULL COMMENT 'in bytes',
-	`MultiUser` ENUM('Yes','No') NOT NULL DEFAULT 'No' COLLATE 'utf8_bin',
-	`Networking` VARCHAR(300) NULL DEFAULT NULL COLLATE 'utf8_bin',
-	`Type` ENUM('GUI','Text') NOT NULL DEFAULT 'GUI' COLLATE 'utf8_bin',
-	`SerialRequired` ENUM('True','False') NOT NULL DEFAULT 'False' COLLATE 'utf8_bin',
-	`InstallInstructions` LONGTEXT NULL DEFAULT NULL COLLATE 'utf8_general_ci',
-	`Notes` LONGTEXT NULL DEFAULT NULL COLLATE 'utf8_general_ci',
-	`Platform` SET('DOS','CPM','Windows','OS2','Unix','Linux','MacOS','Mac OS X','DOSShell','Other') NULL DEFAULT NULL COLLATE 'utf8_bin',
-	`DefaultDownload` BINARY(16) NULL DEFAULT NULL,
-	PRIMARY KEY (`ReleaseUUID`),
-	INDEX `ProductUUID` (`ProductUUID`),
-	INDEX `Slug` (`Slug`),
-	INDEX `ReleaseDate_EndOfLife` (`ReleaseDate`, `EndOfLife`) USING BTREE,
-	INDEX `ReleaseOrder` (`ReleaseOrder`) USING BTREE,
-	INDEX `Platform` (`Platform`),
-	INDEX `Arch` (`Arch`),
-	FULLTEXT INDEX `Name_VendorName_InstallInstructions_Notes` (`InstallInstructions`, `Notes`, `Name`, `VendorName`)
-)
-COLLATE='utf8_bin'
-ENGINE=Aria
-;
+-- Dumping structure for table winworld.downloads
+CREATE TABLE IF NOT EXISTS `downloads` (
+  `DLUUID` binary(16) NOT NULL,
+  `Name` varchar(150) COLLATE utf8_bin NOT NULL,
+  `Version` varchar(40) COLLATE utf8_bin NOT NULL,
+  `RTM` enum('True','False') COLLATE utf8_bin NOT NULL DEFAULT 'True',
+  `OriginalPath` text COLLATE utf8_bin NOT NULL,
+  `DownloadPath` text COLLATE utf8_bin NOT NULL,
+  `ImageType` enum('Archive','35Floppy','525Floppy','CDISO','DVDISO','VPC','VMWARE','VBOX') COLLATE utf8_bin NOT NULL DEFAULT 'Archive',
+  `Arch` set('x86','x86-32','m68k','ppc','amd64','mos6502','ppc64','SPARC','SPARC64','MIPS','MIPS64','Alpha','Other') COLLATE utf8_bin NOT NULL DEFAULT 'x86',
+  `Information` text COLLATE utf8_bin DEFAULT NULL,
+  `ReleaseUUID` binary(16) DEFAULT NULL,
+  `Upgrade` enum('True','False') COLLATE utf8_bin NOT NULL DEFAULT 'False',
+  `VIPOnly` enum('True','False') COLLATE utf8_bin NOT NULL DEFAULT 'False',
+  `Language` varchar(50) COLLATE utf8_bin NOT NULL DEFAULT 'English',
+  `FileSize` bigint(20) DEFAULT NULL,
+  `FileName` varchar(250) COLLATE utf8_bin DEFAULT NULL,
+  `ContributionUUID` binary(16) DEFAULT NULL,
+  `CreatedDate` timestamp NULL DEFAULT current_timestamp(),
+  `LastUpdated` timestamp NULL DEFAULT current_timestamp(),
+  `NoShowOnHome` enum('True','False') COLLATE utf8_bin NOT NULL DEFAULT 'False',
+  `FileHash` varchar(255) COLLATE utf8_bin DEFAULT NULL,
+  PRIMARY KEY (`DLUUID`),
+  KEY `ReleaseUUID` (`ReleaseUUID`),
+  KEY `FileName` (`Name`),
+  KEY `ContributionUUID` (`ContributionUUID`),
+  KEY `NoShowOnHome` (`NoShowOnHome`),
+  KEY `CreatedDate` (`CreatedDate`),
+  KEY `LastUpdated` (`LastUpdated`),
+  FULLTEXT KEY `Information` (`Information`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 
-CREATE TABLE `Screenshots` (
-	`ScreenshotUUID` BINARY(16) NOT NULL,
-	`ReleaseUUID` BINARY(16) NULL DEFAULT NULL,
-	`ScreenshotTitle` VARCHAR(750) NULL DEFAULT NULL COLLATE 'utf8_bin',
-	`ScreenshotFile` VARCHAR(350) NULL DEFAULT NULL COLLATE 'utf8_bin',
-	PRIMARY KEY (`ScreenshotUUID`),
-	INDEX `ReleaseUUID` (`ReleaseUUID`)
-)
-COLLATE='utf8_bin'
-ENGINE=Aria
-;
+-- Dumping data for table winworld.downloads: ~0 rows (approximately)
+/*!40000 ALTER TABLE `downloads` DISABLE KEYS */;
+/*!40000 ALTER TABLE `downloads` ENABLE KEYS */;
 
-CREATE TABLE `Serials` (
-	`ReleaseUUID` BINARY(16) NULL DEFAULT NULL,
-	`Serial` VARCHAR(500) NULL DEFAULT NULL COLLATE 'utf8_bin',
-	INDEX `ReleaseUUID` (`ReleaseUUID`) USING HASH
-)
-COLLATE='utf8_bin'
-ENGINE=Aria
-;
+-- Dumping structure for table winworld.mirrorcontents
+CREATE TABLE IF NOT EXISTS `mirrorcontents` (
+  `MirrorUUID` binary(16) DEFAULT NULL,
+  `DownloadUUID` binary(16) DEFAULT NULL,
+  KEY `UUIDS` (`MirrorUUID`,`DownloadUUID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 
-CREATE TABLE `UserFlagHolders` (
-	`FlagUUID` BINARY(16) NOT NULL,
-	`UserUUID` BINARY(16) NOT NULL,
-	`Added` TIMESTAMP NOT NULL DEFAULT '',
-	INDEX `GroupUUID` (`FlagUUID`),
-	INDEX `UserUUID` (`UserUUID`)
-)
-COLLATE='utf8_bin'
-ENGINE=Aria
-;
+-- Dumping data for table winworld.mirrorcontents: ~0 rows (approximately)
+/*!40000 ALTER TABLE `mirrorcontents` DISABLE KEYS */;
+/*!40000 ALTER TABLE `mirrorcontents` ENABLE KEYS */;
 
-CREATE TABLE `UserFlags` (
-	`FlagUUID` BINARY(16) NOT NULL,
-	`FlagName` VARCHAR(15) NOT NULL,
-	`LongName` VARCHAR(250) NOT NULL,
-	`SystemFlag` ENUM('True','False') NOT NULL DEFAULT 'False',
-	`Preemptive` ENUM('True','False') NOT NULL DEFAULT 'False',
-	`PublicVisible` ENUM('True','False') NOT NULL DEFAULT 'False',
-	`FlagColour` VARCHAR(10) NULL DEFAULT NULL,
-	PRIMARY KEY (`FlagUUID`),
-	UNIQUE INDEX `FlagName` (`FlagName`)
-)
-COLLATE='utf8_general_ci'
-ENGINE=InnoDB
-;
+-- Dumping structure for table winworld.products
+CREATE TABLE IF NOT EXISTS `products` (
+  `ProductUUID` binary(16) NOT NULL,
+  `DiscussionUUID` binary(16) NOT NULL,
+  `Name` varchar(150) NOT NULL,
+  `Slug` varchar(100) DEFAULT NULL,
+  `Notes` text NOT NULL,
+  `LogoImage` varchar(150) DEFAULT NULL,
+  `Type` enum('OS','Game','Application','DevTool','System') NOT NULL DEFAULT 'Application',
+  `ProductCreated` timestamp NULL DEFAULT current_timestamp(),
+  `DefaultRelease` binary(16) DEFAULT NULL,
+  `ApplicationTags` set('Word Processor','Spreadsheet','Presentations','Web Browser','Chat','Utility','Graphics','Publishing','Financial','Reference','Editor','Communications','Novelty','PIM','Video','Audio','Document','Media Player','Virtualization','Archive','Other','Server','Database','Mathematics','Planning','Education','Engineering') DEFAULT NULL,
+  PRIMARY KEY (`ProductUUID`),
+  KEY `Name_Slug` (`Name`,`Slug`),
+  KEY `Type_Platform` (`Type`),
+  KEY `DefaultRelease` (`DefaultRelease`),
+  KEY `ApplicationTags` (`ApplicationTags`),
+  KEY `DiscussionUUID` (`DiscussionUUID`),
+  FULLTEXT KEY `Notes` (`Notes`),
+  FULLTEXT KEY `Name_Notes` (`Name`,`Notes`),
+  FULLTEXT KEY `Name` (`Name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-CREATE TABLE `Users` (
-	`UserID` BINARY(16) NOT NULL,
-	`Email` VARCHAR(80) NOT NULL COLLATE 'utf8_unicode_ci',
-	`AccountEnabled` ENUM('True','False') NOT NULL DEFAULT 'True' COLLATE 'utf8_unicode_ci',
-	`Password` VARCHAR(64) NOT NULL COLLATE 'utf8_unicode_ci',
-	`Salt` VARCHAR(64) NULL DEFAULT NULL COLLATE 'utf8_unicode_ci',
-	`ShortName` VARCHAR(64) NULL DEFAULT NULL COLLATE 'utf8_unicode_ci',
-	`RegistrationTime` TIMESTAMP NOT NULL DEFAULT '',
-	`LastSeenTime` TIMESTAMP NOT NULL DEFAULT '',
-	`RegistrationIP` VARCHAR(45) NOT NULL COLLATE 'utf8_unicode_ci',
-	`ThemeName` VARCHAR(50) NOT NULL DEFAULT 'default' COLLATE 'utf8_unicode_ci',
-	PRIMARY KEY (`UserID`),
-	UNIQUE INDEX `UniqueVals` (`ShortName`, `Email`)
-)
-COLLATE='utf8_unicode_ci'
-ENGINE=Aria
-ROW_FORMAT=
-;
+-- Dumping data for table winworld.products: ~0 rows (approximately)
+/*!40000 ALTER TABLE `products` DISABLE KEYS */;
+/*!40000 ALTER TABLE `products` ENABLE KEYS */;
 
-CREATE TABLE `UserRecoverPasswordRequests` (
-	`RequestID` BINARY(16) NOT NULL,
-	`UserID` BINARY(16) NOT NULL,
-	`DateCreated` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-	PRIMARY KEY (`RequestID`),
-	UNIQUE INDEX `UserID` (`UserID`),
-	UNIQUE INDEX `RequestID` (`RequestID`)
-)
-COLLATE='utf8_general_ci'
-ENGINE=InnoDB
-;
+-- Dumping structure for table winworld.releases
+CREATE TABLE IF NOT EXISTS `releases` (
+  `ReleaseUUID` binary(16) NOT NULL,
+  `ProductUUID` binary(16) NOT NULL,
+  `Name` varchar(50) CHARACTER SET utf8 NOT NULL,
+  `VendorName` varchar(50) CHARACTER SET utf8 DEFAULT NULL,
+  `Slug` varchar(100) COLLATE utf8_bin DEFAULT NULL,
+  `ReleaseOrder` int(11) NOT NULL DEFAULT 0,
+  `ReleaseDate` timestamp NULL DEFAULT NULL,
+  `EndOfLife` timestamp NULL DEFAULT NULL,
+  `FuzzyDate` enum('True','False') COLLATE utf8_bin NOT NULL DEFAULT 'False',
+  `Arch` set('x86','x86-32','m68k','ppc','amd64','mos6502','ppc64','SPARC','SPARC64','MIPS','MIPS64','Alpha','Other') COLLATE utf8_bin DEFAULT NULL,
+  `RAMRequirement` int(10) unsigned DEFAULT NULL COMMENT 'in bytes',
+  `CPURequirement` varchar(50) COLLATE utf8_bin DEFAULT NULL,
+  `DiskSpaceRequired` int(10) unsigned DEFAULT NULL COMMENT 'in bytes',
+  `MultiUser` enum('Yes','No') COLLATE utf8_bin NOT NULL DEFAULT 'No',
+  `Networking` varchar(300) COLLATE utf8_bin DEFAULT NULL,
+  `Type` enum('GUI','Text') COLLATE utf8_bin NOT NULL DEFAULT 'GUI',
+  `SerialRequired` enum('True','False') COLLATE utf8_bin NOT NULL DEFAULT 'False',
+  `InstallInstructions` longtext CHARACTER SET utf8 DEFAULT NULL,
+  `Notes` longtext CHARACTER SET utf8 DEFAULT NULL,
+  `Platform` set('DOS','CPM','Windows','OS2','Unix','Linux','MacOS','Mac OS X','DOSShell','Other') COLLATE utf8_bin DEFAULT NULL,
+  `DefaultDownload` binary(16) DEFAULT NULL,
+  PRIMARY KEY (`ReleaseUUID`),
+  KEY `ProductUUID` (`ProductUUID`),
+  KEY `Slug` (`Slug`),
+  KEY `ReleaseDate_EndOfLife` (`ReleaseDate`,`EndOfLife`) USING BTREE,
+  KEY `ReleaseOrder` (`ReleaseOrder`) USING BTREE,
+  KEY `Platform` (`Platform`),
+  KEY `Arch` (`Arch`),
+  FULLTEXT KEY `Name_VendorName_InstallInstructions_Notes` (`InstallInstructions`,`Notes`,`Name`,`VendorName`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 
--- These triggers will create new UUIDs for each item type addressable by UUIDs.
--- The definer should match the SQL user you use for Adventure.
+-- Dumping data for table winworld.releases: ~0 rows (approximately)
+/*!40000 ALTER TABLE `releases` DISABLE KEYS */;
+/*!40000 ALTER TABLE `releases` ENABLE KEYS */;
 
-CREATE DEFINER=`root`@`localhost` TRIGGER `BeforeCreateContribution` BEFORE INSERT ON `Contributions` FOR EACH ROW BEGIN
-    SET NEW.ContributionUUID = UUIDBIN(UUID());
-END
+-- Dumping structure for table winworld.screenshots
+CREATE TABLE IF NOT EXISTS `screenshots` (
+  `ScreenshotUUID` binary(16) NOT NULL,
+  `ReleaseUUID` binary(16) DEFAULT NULL,
+  `ScreenshotTitle` varchar(750) COLLATE utf8_bin DEFAULT NULL,
+  `ScreenshotFile` varchar(350) COLLATE utf8_bin DEFAULT NULL,
+  PRIMARY KEY (`ScreenshotUUID`),
+  KEY `ReleaseUUID` (`ReleaseUUID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 
-CREATE DEFINER=`root`@`localhost` TRIGGER `BeforeCreateDownload` BEFORE INSERT ON `Downloads` FOR EACH ROW BEGIN
-    SET New.DLUUID = UUIDBIN(UUID());
-END
+-- Dumping data for table winworld.screenshots: ~0 rows (approximately)
+/*!40000 ALTER TABLE `screenshots` DISABLE KEYS */;
+/*!40000 ALTER TABLE `screenshots` ENABLE KEYS */;
 
-CREATE DEFINER=`root`@`localhost` TRIGGER `BeforeCreateFlags` BEFORE INSERT ON `UserFlags` FOR EACH ROW BEGIN
-	SET NEW.FlagUUID = UUIDBIN(UUID());
-END
+-- Dumping structure for table winworld.serials
+CREATE TABLE IF NOT EXISTS `serials` (
+  `ReleaseUUID` binary(16) DEFAULT NULL,
+  `Serial` varchar(500) COLLATE utf8_bin DEFAULT NULL,
+  KEY `ReleaseUUID` (`ReleaseUUID`) USING HASH
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 
-CREATE DEFINER=`root`@`localhost` TRIGGER `BeforeCreateMirror` BEFORE INSERT ON `DownloadMirrors` FOR EACH ROW BEGIN
-    SET NEW.MirrorUUID = UUIDBIN(UUID());
-END
+-- Dumping data for table winworld.serials: ~0 rows (approximately)
+/*!40000 ALTER TABLE `serials` DISABLE KEYS */;
+/*!40000 ALTER TABLE `serials` ENABLE KEYS */;
 
-CREATE DEFINER=`root`@`localhost` TRIGGER `BeforeCreateProduct` BEFORE INSERT ON `Products` FOR EACH ROW BEGIN
-	SET NEW.ProductUUID = UUIDBIN(UUID());
-END
+-- Dumping structure for table winworld.userflagholders
+CREATE TABLE IF NOT EXISTS `userflagholders` (
+  `FlagUUID` binary(16) NOT NULL,
+  `UserUUID` binary(16) NOT NULL,
+  `Added` timestamp NOT NULL DEFAULT current_timestamp(),
+  KEY `GroupUUID` (`FlagUUID`),
+  KEY `UserUUID` (`UserUUID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 
-CREATE DEFINER=`root`@`localhost` TRIGGER `BeforeCreateRelease` BEFORE INSERT ON `Releases` FOR EACH ROW BEGIN
-   SET NEW.ReleaseUUID = UUIDBIN(UUID());
-END
+-- Dumping data for table winworld.userflagholders: ~1 rows (approximately)
+/*!40000 ALTER TABLE `userflagholders` DISABLE KEYS */;
+INSERT IGNORE INTO `userflagholders` (`FlagUUID`, `UserUUID`, `Added`) VALUES
+	(_binary 0x25C5A043C3867BC2B311C3A4C29D7100, _binary 0x7B05DE4D3F2111E88D2AFA163E9022F0, '2017-08-02 04:26:41');
+/*!40000 ALTER TABLE `userflagholders` ENABLE KEYS */;
 
-CREATE DEFINER=`root`@`localhost` TRIGGER `BeforeCreateScreenshot` BEFORE INSERT ON `Screenshots` FOR EACH ROW BEGIN
-	SET NEW.ScreenshotUUID = UUIDBIN(UUID());
-END
+-- Dumping structure for table winworld.userflags
+CREATE TABLE IF NOT EXISTS `userflags` (
+  `FlagUUID` binary(16) NOT NULL,
+  `FlagName` varchar(15) NOT NULL,
+  `LongName` varchar(250) NOT NULL,
+  `SystemFlag` enum('True','False') NOT NULL DEFAULT 'False',
+  `Preemptive` enum('True','False') NOT NULL DEFAULT 'False',
+  `PublicVisible` enum('True','False') NOT NULL DEFAULT 'False',
+  `FlagColour` varchar(10) DEFAULT NULL,
+  PRIMARY KEY (`FlagUUID`),
+  UNIQUE KEY `FlagName` (`FlagName`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-CREATE DEFINER=`root`@`localhost` TRIGGER `BeforeCreateUser` BEFORE INSERT ON `Users` FOR EACH ROW BEGIN
-	SET NEW.UserID = UUIDBIN(UUID());
-	SET NEW.RegistrationTime = NOW();
-END
+-- Dumping data for table winworld.userflags: ~0 rows (approximately)
+/*!40000 ALTER TABLE `userflags` DISABLE KEYS */;
+INSERT IGNORE INTO `userflags` (`FlagUUID`, `FlagName`, `LongName`, `SystemFlag`, `Preemptive`, `PublicVisible`, `FlagColour`) VALUES
+	(_binary 0x11E99BFCD1E51F4C853FE86A64A6C64B, 'sa', 'Site Admin', 'True', 'False', 'True', 'primary'),
+	(_binary 0x11E99BFCD1E77AC6853FE86A64A6C64B, 'vip', 'VIP Member', 'False', 'False', 'True', 'success');
+/*!40000 ALTER TABLE `userflags` ENABLE KEYS */;
 
-CREATE DEFINER=`root`@`localhost` TRIGGER `BeforeCreateRecoverPassword` BEFORE INSERT ON `UserRecoverPasswordRequests` FOR EACH ROW BEGIN
+-- Dumping structure for table winworld.userrecoverpasswordrequests
+CREATE TABLE IF NOT EXISTS `userrecoverpasswordrequests` (
+  `RequestID` binary(16) NOT NULL,
+  `UserID` binary(16) NOT NULL,
+  `DateCreated` timestamp NOT NULL DEFAULT current_timestamp(),
+  PRIMARY KEY (`RequestID`),
+  UNIQUE KEY `UserID` (`UserID`),
+  UNIQUE KEY `RequestID` (`RequestID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+-- Dumping data for table winworld.userrecoverpasswordrequests: ~0 rows (approximately)
+/*!40000 ALTER TABLE `userrecoverpasswordrequests` DISABLE KEYS */;
+/*!40000 ALTER TABLE `userrecoverpasswordrequests` ENABLE KEYS */;
+
+-- Dumping structure for table winworld.users
+CREATE TABLE IF NOT EXISTS `users` (
+  `UserID` binary(16) NOT NULL,
+  `Email` varchar(80) COLLATE utf8_unicode_ci NOT NULL,
+  `AccountEnabled` enum('True','False') COLLATE utf8_unicode_ci NOT NULL DEFAULT 'True',
+  `Password` varchar(64) COLLATE utf8_unicode_ci NOT NULL,
+  `Salt` varchar(64) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `ShortName` varchar(64) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `RegistrationTime` timestamp NOT NULL DEFAULT current_timestamp(),
+  `LastSeenTime` timestamp NOT NULL DEFAULT current_timestamp(),
+  `RegistrationIP` varchar(45) COLLATE utf8_unicode_ci NOT NULL,
+  `ThemeName` varchar(50) COLLATE utf8_unicode_ci NOT NULL DEFAULT 'default',
+  PRIMARY KEY (`UserID`),
+  UNIQUE KEY `UniqueVals` (`ShortName`,`Email`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+
+-- Dumping data for table winworld.users: ~0 rows (approximately)
+/*!40000 ALTER TABLE `users` DISABLE KEYS */;
+INSERT IGNORE INTO `users` (`UserID`, `Email`, `AccountEnabled`, `Password`, `Salt`, `ShortName`, `RegistrationTime`, `LastSeenTime`, `RegistrationIP`, `ThemeName`) VALUES
+	(_binary 0x11E99BFCD1E9E3F7853FE86A64A6C64B, 'root@localhost', 'True', '$2a$12$I7Z0lrQFyxgRFgWVB8FX1.FYpJDEN7Z5x4Mp4a7I8bT26G3OU8USa', '', 'admin', '2019-07-01 14:36:16', '2018-04-07 00:27:28', '', 'default');
+/*!40000 ALTER TABLE `users` ENABLE KEYS */;
+
+-- Dumping structure for function winworld.UUIDBIN
+DELIMITER //
+CREATE DEFINER=`root`@`localhost` FUNCTION `UUIDBIN`(_uuid BINARY(36)) RETURNS binary(16)
+    DETERMINISTIC
+    SQL SECURITY INVOKER
+RETURN
+        UNHEX(CONCAT(
+            SUBSTR(_uuid, 15, 4),
+            SUBSTR(_uuid, 10, 4),
+            SUBSTR(_uuid,  1, 8),
+            SUBSTR(_uuid, 20, 4),
+            SUBSTR(_uuid, 25) ))//
+DELIMITER ;
+
+-- Dumping structure for trigger winworld.BeforeCreateContribution
+SET @OLDTMP_SQL_MODE=@@SQL_MODE, SQL_MODE='STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION';
+DELIMITER //
+CREATE TRIGGER `BeforeCreateContribution` BEFORE INSERT ON `contributions` FOR EACH ROW BEGIN
+SET NEW.ContributionUUID = UUIDBIN(UUID());
+END//
+DELIMITER ;
+SET SQL_MODE=@OLDTMP_SQL_MODE;
+
+-- Dumping structure for trigger winworld.BeforeCreateDownload
+SET @OLDTMP_SQL_MODE=@@SQL_MODE, SQL_MODE='STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION';
+DELIMITER //
+CREATE TRIGGER `BeforeCreateDownload` BEFORE INSERT ON `downloads` FOR EACH ROW BEGIN
+SET New.DLUUID = UUIDBIN(UUID());
+END//
+DELIMITER ;
+SET SQL_MODE=@OLDTMP_SQL_MODE;
+
+-- Dumping structure for trigger winworld.BeforeCreateFlags
+SET @OLDTMP_SQL_MODE=@@SQL_MODE, SQL_MODE='STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION';
+DELIMITER //
+CREATE TRIGGER `BeforeCreateFlags` BEFORE INSERT ON `userflags` FOR EACH ROW BEGIN
+SET NEW.FlagUUID = UUIDBIN(UUID());
+END//
+DELIMITER ;
+SET SQL_MODE=@OLDTMP_SQL_MODE;
+
+-- Dumping structure for trigger winworld.BeforeCreateMirror
+SET @OLDTMP_SQL_MODE=@@SQL_MODE, SQL_MODE='STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION';
+DELIMITER //
+CREATE TRIGGER `BeforeCreateMirror` BEFORE INSERT ON `downloadmirrors` FOR EACH ROW BEGIN
+SET NEW.MirrorUUID = UUIDBIN(UUID());
+END//
+DELIMITER ;
+SET SQL_MODE=@OLDTMP_SQL_MODE;
+
+-- Dumping structure for trigger winworld.BeforeCreateProduct
+SET @OLDTMP_SQL_MODE=@@SQL_MODE, SQL_MODE='STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION';
+DELIMITER //
+CREATE TRIGGER `BeforeCreateProduct` BEFORE INSERT ON `products` FOR EACH ROW BEGIN
+SET NEW.ProductUUID = UUIDBIN(UUID());
+END//
+DELIMITER ;
+SET SQL_MODE=@OLDTMP_SQL_MODE;
+
+-- Dumping structure for trigger winworld.BeforeCreateRecoverPassword
+SET @OLDTMP_SQL_MODE=@@SQL_MODE, SQL_MODE='STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION';
+DELIMITER //
+CREATE TRIGGER `BeforeCreateRecoverPassword` BEFORE INSERT ON `userrecoverpasswordrequests` FOR EACH ROW BEGIN
 	SET NEW.RequestID = UUIDBIN(UUID());
 	SET NEW.DateCreated = NOW();
-END
+END//
+DELIMITER ;
+SET SQL_MODE=@OLDTMP_SQL_MODE;
 
--- This is to create an administrative user and initial flags.
--- By default, the user's password is "changeme" - for obvious reasons, change this!
+-- Dumping structure for trigger winworld.BeforeCreateRelease
+SET @OLDTMP_SQL_MODE=@@SQL_MODE, SQL_MODE='STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION';
+DELIMITER //
+CREATE TRIGGER `BeforeCreateRelease` BEFORE INSERT ON `releases` FOR EACH ROW BEGIN
+SET NEW.ReleaseUUID = UUIDBIN(UUID());
+END//
+DELIMITER ;
+SET SQL_MODE=@OLDTMP_SQL_MODE;
 
--- The "VIP" user is configured to have twice the downloads per day; while site admin is self-explanatory.
+-- Dumping structure for trigger winworld.BeforeCreateScreenshot
+SET @OLDTMP_SQL_MODE=@@SQL_MODE, SQL_MODE='STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION';
+DELIMITER //
+CREATE TRIGGER `BeforeCreateScreenshot` BEFORE INSERT ON `screenshots` FOR EACH ROW BEGIN
+SET NEW.ScreenshotUUID = UUIDBIN(UUID());
+END//
+DELIMITER ;
+SET SQL_MODE=@OLDTMP_SQL_MODE;
 
-INSERT INTO `UserFlags` (`FlagUUID`, `FlagName`, `LongName`, `SystemFlag`, `Preemptive`, `PublicVisible`, `FlagColour`) VALUES (0x25C5A043C3867BC2B311C3A4C29D7100, 'sa', 'Site Admin', 'True', 'False', 'True', 'primary');
-INSERT INTO `UserFlags` (`FlagUUID`, `FlagName`, `LongName`, `SystemFlag`, `Preemptive`, `PublicVisible`, `FlagColour`) VALUES (0x3EC2B140127BC2B311C3A4C29D710015, 'vip', 'VIP Member', 'False', 'False', 'True', 'success');
+-- Dumping structure for trigger winworld.BeforeCreateUser
+SET @OLDTMP_SQL_MODE=@@SQL_MODE, SQL_MODE='STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION';
+DELIMITER //
+CREATE TRIGGER `BeforeCreateUser` BEFORE INSERT ON `users` FOR EACH ROW BEGIN
+	SET NEW.UserID = UUIDBIN(UUID());
+	SET NEW.RegistrationTime = NOW();
+END//
+DELIMITER ;
+SET SQL_MODE=@OLDTMP_SQL_MODE;
 
-INSERT INTO `Users` (`UserID`, `Email`, `AccountEnabled`, `Password`, `Salt`, `ShortName`, `RegistrationTime`, `LastSeenTime`, `RegistrationIP`, `ThemeName`) VALUES (0x7B05DE4D3F2111E88D2AFA163E9022F0, 'root@localhost', 'True', '$2a$12$I7Z0lrQFyxgRFgWVB8FX1.FYpJDEN7Z5x4Mp4a7I8bT26G3OU8USa', '', 'admin', '2014-08-13 10:42:20', '2018-04-07 00:27:28', '', 'default');
-
-INSERT INTO `UserFlagHolders` (`FlagUUID`, `UserUUID`, `Added`) VALUES (0x25C5A043C3867BC2B311C3A4C29D7100, 0x7B05DE4D3F2111E88D2AFA163E9022F0, '2017-08-02 04:26:41');
-
--- This function is for supporting the triggers above.
-
-CREATE DEFINER=`root`@`localhost` FUNCTION `UUIDBIN`(
-	`_uuid` TINYTEXT
-
-
-
-)
-RETURNS binary(16)
-LANGUAGE SQL
-DETERMINISTIC
-NO SQL
-SQL SECURITY DEFINER
-COMMENT ''
-BEGIN
-	RETURN UNHEX(REPLACE(_uuid, '-', ''));
-END
+/*!40101 SET SQL_MODE=IFNULL(@OLD_SQL_MODE, '') */;
+/*!40014 SET FOREIGN_KEY_CHECKS=IF(@OLD_FOREIGN_KEY_CHECKS IS NULL, 1, @OLD_FOREIGN_KEY_CHECKS) */;
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;

--- a/adventure/saDownloadRoutes.js
+++ b/adventure/saDownloadRoutes.js
@@ -100,8 +100,8 @@ server.post("/sa/editDownloadMetadata/:download", restrictedRoute("sa"), urlenco
         var arch = formatting.dbStringifySelect(req.body.arch);
         var rtm = req.body.rtm ? "True" : "False";
         var upgrade = req.body.upgrade ? "True" : "False";
-        var dbParams = [releaseUuidAsBuf, req.body.name, arch, req.body.version, rtm, upgrade, req.body.information, req.body.language, req.body.imageType, req.body.fileSize, req.body.downloadPath, req.body.downloadPath, req.body.fileName, new Date(), req.body.fileHash, formatting.hexToBin(uuid)];
-        database.execute("UPDATE Downloads SET ReleaseUUID = ?, Name = ?, Arch = ?, Version = ?, RTM = ?, Upgrade = ?, Information = ?, Language = ?, ImageType = ?, FileSize = ?, DownloadPath = ?, OriginalPath = ?, FileName = ?, LastUpdated = ?, FileHash = ? WHERE DLUUID = ?", dbParams, function (rlErr, rlRes, rlFields) {
+        var dbParams = [releaseUuidAsBuf, req.body.name, arch, req.body.version, rtm, upgrade, req.body.information, req.body.language, req.body.imageType, req.body.fileSize, req.body.downloadPath, req.body.downloadPath, req.body.fileName, new Date(), req.body.fileHash, req.body.ipfsPath, formatting.hexToBin(uuid)];
+        database.execute("UPDATE Downloads SET ReleaseUUID = ?, Name = ?, Arch = ?, Version = ?, RTM = ?, Upgrade = ?, Information = ?, Language = ?, ImageType = ?, FileSize = ?, DownloadPath = ?, OriginalPath = ?, FileName = ?, LastUpdated = ?, FileHash = ?, IPFSPath = ? WHERE DLUUID = ?", dbParams, function (rlErr, rlRes, rlFields) {
             if (rlErr) {
                 return res.status(500).render("error", {
                     message: "The download could not be edited."

--- a/adventure/views/head.ejs
+++ b/adventure/views/head.ejs
@@ -5,6 +5,7 @@
     <meta name="generator" content="Adventure" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
+	<script src="https://unpkg.com/ipfs-http-client@32.0.1/dist/index.min.js" integrity="sha384-DHwXHSTSL/db8jvqXZXPTbr/QXZsSYe2tSi5avrkdKXTfAK1CctqVCv5YOl4A8uc" crossorigin="anonymous"></script>
     <link rel="stylesheet" href="/res/css/stickyFooter.css" />
     <%- headerFragment %>
     <!-- RSS feeds -->

--- a/adventure/views/saDownload.ejs
+++ b/adventure/views/saDownload.ejs
@@ -93,6 +93,15 @@
             <input required type="text" class="form-control" id="fileName" name="fileName" placeholder="File name" value="<%= download.FileName %>">
         </div>
     </div>
+	<div class="row">
+		<div class="form-group col">
+			<label for="ipfsPath">IPFS Path</label>
+			<input type="text" class="form-control" id="ipfsPath" name="ipfsPath" placeholder="IPFS Path" value="<%=download.IPFSPath%>">
+			<small class="form-text text-muted">
+			Leave this field empty to disable IPFS for this download.
+			</small>
+		</div>
+	</div>
     <button type="submit" class="btn btn-primary">Submit</button>
     <a class="btn btn-outline-primary" href="/download/<%= download.DLUUID %>">Cancel</a>
 </form>

--- a/adventure/views/selectMirror.ejs
+++ b/adventure/views/selectMirror.ejs
@@ -28,8 +28,14 @@
 		<% if (download.IPFSPath) { %>
 		<h2>IPFS</h2>
 		<p>This file is also available over <a href="https://ipfs.io/">IPFS</a>. IPFS is a decentralised distributed file store, and thus downloads do not count towards your daily download limit.</p>
+
 		<p><i>Warning: IPFS support is currently experimental and your download might not work.</i></p>
-		<p id="localIPFSClientMessage">No local IPFS client has been detected. To use the IPFS client, visit <a href="https://ipfs.io">ipfs.io</a> to install the IPFS Companion browser extention and download and run a client.<br />Alternatively, you can also use the <a href="https://brave.com/but305">Brave browser</a>, which, in addition to built-in ad-blocking and strong privacy options, also offers a built-in IPFS client.</p>
+
+		<p id="localIPFSClientMessage">
+			No local IPFS client has been detected. To use the IPFS client, visit <a href="https://ipfs.io">ipfs.io</a> to install the IPFS Companion browser extention and download and run a client.<br />
+			
+		</p>
+
 		<p>Download through</p>
 		<ul>
 			<li><a href="https://cloudflare-ipfs.com<%=download.IPFSPath%>">Cloudflare IPFS Gateway</a></li>

--- a/adventure/views/selectMirror.ejs
+++ b/adventure/views/selectMirror.ejs
@@ -25,6 +25,49 @@
             <li><a href="/download/<%= download.DLUUID %>/from/<%= i.MirrorUUID %>"><%= i.MirrorName %></a> (<%= i.Location %>, <%= i.Country %>)</li>
             <% }); %>
         </ul>
+		<% if (download.IPFSPath) { %>
+		<h2>IPFS</h2>
+		<p>This file is also available over <a href="https://ipfs.io/">IPFS</a>. IPFS is a decentralised distributed file store, and thus downloads do not count towards your daily download limit.</p>
+		<p><i>Warning: IPFS support is currently experimental and your download might not work.</i></p>
+		<p id="localIPFSClientMessage">No local IPFS client has been detected. To use the IPFS client, visit <a href="https://ipfs.io">ipfs.io</a> to install the IPFS Companion browser extention and download and run a client.<br />Alternatively, you can also use the <a href="https://brave.com/but305">Brave browser</a>, which, in addition to built-in ad-blocking and strong privacy options, also offers a built-in IPFS client.</p>
+		<p>Download through</p>
+		<ul>
+			<li><a href="https://cloudflare-ipfs.com<%=download.IPFSPath%>">Cloudflare IPFS Gateway</a></li>
+			<li id="localClientLink" style="display: none;">Local client: <a href="dweb:<%=download.IPFSPath%>"><%=download.IPFSPath%></a></li>
+		</ul>
+		<script>
+			(() => {
+				const localClientLink = document.getElementById('localClientLink')
+				const localIPFSClientMessage = document.getElementById('localIPFSClientMessage')
+
+				const getIpfs = () => new Promise((resolve, reject) => {
+					if (window.ipfs) {
+						if (window.ipfs.enable) {
+							return resolve(window.ipfs.enable({commands: ['id', 'version']}))
+						}
+						return resolve(window.ipfs);
+					}
+					reject();
+				})
+
+				const log = (msg) => {
+					console.log(msg)
+				}
+
+				const IPFSAvailable = (id) => {
+					log(`running ${id.agentVersion} with ID ${id.id}`)
+					localClientLink.style.display = ""
+					localIPFSClientMessage.style.display = "none"
+				}
+
+				getIpfs()
+					.then(ipfs => ipfs.id()
+					.then(id => IPFSAvailable(id)))
+					.catch(log)
+				
+			})()
+		</script>
+		<% }%>
     </div>
     <div class="col-sm">
         <div id="fileInfoSheet" class="card">


### PR DESCRIPTION
This PR adds IPFS support and fixes two minor issues.

# IPFS support

You can now add an IPFS path to a download and as an admin, and the following behaviour is observed:

* if no IPFS path is added to the download, the user journey does not change
* if an IPFS path is specified, the user can use IPFS to download said file.
  * if a local IPFS client is detected, it is offered to be used
  * if no local IPFS client is detected, a paragraph is shown on how to get one
  * the Cloudflare IPFS gateway is offered as a IPFS gateway as well to download the file.


# Minor fixes
_install.sql bitrot_

The deployment script included in the repo does not generate a functional database anymore for local deployment/testing. I've reconstructed a new one based on the current scheme.

_.gitingore contents_

I've added the `config.json` file to the `.gitignore` file to reduce the chance of secrets being committed to the git repo.