### PR TITLE
Public profile pages and basic contribution management

### DIFF
--- a/adventure/config.example.json
+++ b/adventure/config.example.json
@@ -32,6 +32,7 @@
   "viewDirectory": "views",
   "resDirectory": "res",
   "usersCanChangeTheme": true,
+  "allowContributions": true,
 
   "constants": {
     "tagMappings": {

--- a/adventure/libraryRoutes.js
+++ b/adventure/libraryRoutes.js
@@ -122,6 +122,13 @@ function libraryRoute(req, res) {
         });
     }
 }
+
+server.get("/library/contribute", restrictedRoute(), function (req, res) {
+    return res.render("contribute", {
+        platformMappingsInverted: formatting.invertObject(config.constants.platformMappings)
+    });
+});
+
 server.get("/library/:category", libraryRoute);
 server.get("/library/:category/:tag", libraryRoute);
 server.get("/library", function (req, res) {

--- a/adventure/libraryRoutes.js
+++ b/adventure/libraryRoutes.js
@@ -125,6 +125,11 @@ function libraryRoute(req, res) {
 
 // These are first so that they aren't overridden by the category routes
 server.get("/library/contribute", restrictedRoute(), function (req, res) {
+    if (!config.allowContributions) { // If allowContributions is FALSE
+        return res.status(500).render("error", {
+            message: "Contributions aren't being accepted at this time."
+        });
+    }
     return res.render("contribute", {
         platformMappingsInverted: formatting.invertObject(config.constants.platformMappings)
     });

--- a/adventure/saContributionRoutes.js
+++ b/adventure/saContributionRoutes.js
@@ -63,7 +63,8 @@ server.post("/sa/rejectContribution/:contribution", restrictedRoute("sa"), urlen
         var uuidAsBuf = formatting.hexToBin(uuid);
         var status = "Rejected";
         var rejectionReason = req.body.rejectionReason;
-        database.execute("UPDATE `Contributions` SET `Status` = ?, `RejectionReason` = ? WHERE `ContributionUUID` = ?", [status, rejectionReason, uuidAsBuf], function (scErr, scRes, scFields) {
+        var userIdAsBuf = req.user.UserID;
+        database.execute("UPDATE `Contributions` SET `Status` = ?, `RejectionReason` = ?, ProcessTime = NOW(), ProcessBy = ? WHERE `ContributionUUID` = ?", [status, rejectionReason, userIdAsBuf, uuidAsBuf], function (scErr, scRes, scFields) {
             if (scErr) {
                 return res.status(500).render("error", {
                     message: "The contribution could not be rejected."

--- a/adventure/saContributionRoutes.js
+++ b/adventure/saContributionRoutes.js
@@ -1,4 +1,4 @@
-﻿var express = require("express"),
+var express = require("express"),
     fs = require("fs"),
     path = require("path"),
     middleware = require("./middleware.js"),
@@ -18,7 +18,7 @@ server.get("/sa/contributions", restrictedRoute("sa"), function (req, res) {
         var pages = Math.ceil(count / config.perPage);
         database.execute("SELECT * FROM `Contributions` WHERE `Status` = ? ORDER BY ContributionCreated DESC LIMIT ?,?", [status, (page - 1) * config.perPage, config.perPage], function (coErr, coRes, coFields) {
             var contributions = coRes.map(function (x) {
-                x.UserUUID = formatting.binToHex(x.ContributionUUID);
+                x.UserUUID = formatting.binToHex(x.UserUUID);
                 x.ContributionUUID = formatting.binToHex(x.ContributionUUID);
                 return x;
             });
@@ -31,6 +31,54 @@ server.get("/sa/contributions", restrictedRoute("sa"), function (req, res) {
         });
     });
 });
+
+server.get("/sa/contribution/:contribution", restrictedRoute("sa"), function (req, res) {
+    database.execute("SELECT * FROM `Contributions` WHERE `ContributionUUID` = ?", [formatting.hexToBin(req.params.contribution)], function (cErr, cRes, cFields) {
+        // now get any perphiery stuff
+
+        var contribution = cRes[0] || null;
+        if (cErr || contribution == null) {
+            return res.status(404).render("error", {
+                message: "There is no contribution."
+            });
+        }
+
+        var contributions = cRes.map(function (x) {
+            x.UserUUID = formatting.binToHex(x.UserUUID);
+            x.ContributionUUID = formatting.binToHex(x.ContributionUUID);
+            return x;
+        });
+
+        return res.render("saContribution", {
+            contribution: contribution,
+            platformMappingsInverted: formatting.invertObject(config.constants.platformMappings)
+        });
+
+    });
+});
+
+server.post("/sa/rejectContribution/:contribution", restrictedRoute("sa"), urlencodedParser, function (req, res) {
+    if (req.body && req.body.rejectionReason) {
+        var uuid = req.params.contribution;
+        var uuidAsBuf = formatting.hexToBin(uuid);
+        var status = "Rejected";
+        var rejectionReason = req.body.rejectionReason;
+        database.execute("UPDATE `Contributions` SET `Status` = ?, `RejectionReason` = ? WHERE `ContributionUUID` = ?", [status, rejectionReason, uuidAsBuf], function (scErr, scRes, scFields) {
+            if (scErr) {
+                return res.status(500).render("error", {
+                    message: "The contribution could not be rejected."
+                });
+            } else {
+                return res.redirect("/sa/contributions");
+            }
+        });
+    } else {
+        return res.status(400).render("error", {
+            message: "The request was malformed."
+        });
+    }
+});
+
 
 module.exports = function (c, d) {
     config = c

--- a/adventure/userRoutes.js
+++ b/adventure/userRoutes.js
@@ -114,6 +114,30 @@ server.get("/user/edit", restrictedRoute(), function (req, res) {
     return res.render("editProfile");
 });
 
+server.get("/user/profile", restrictedRoute(), function (req, res) {
+    return res.redirect("/user/profile/" + req.user.ShortName);
+});
+
+server.get("/user/profile/:name", function (req, res) {
+    database.userByName(req.params.name, function (err, user) {
+        if (err) {
+            return res.status(500).render("error", {
+                message: "There was an error fetching from the database."
+            });
+        } else if (user == null) {
+            return res.status(404).render("error", {
+                message: "There was no user."
+            });
+        } else {
+            user.UserID = formatting.binToHex(user.UserID);
+            res.render("publicProfile", {
+                viewingUser: user,
+                userFlags: database.userFlags,
+            });
+        }
+    });
+});
+
 server.post("/user/changepw", restrictedRoute(), urlencodedParser, function (req, res) {
     if (req.body && req.body.password && req.body.newPassword && req.body.newPasswordR) {
         formatting.checkPassword(req.body.password, req.user.Salt, req.user.Password, function(checkErr, success) {

--- a/adventure/userRoutes.js
+++ b/adventure/userRoutes.js
@@ -125,8 +125,18 @@ server.get("/user/profile/:name", function (req, res) {
                 message: "There was an error fetching from the database."
             });
         } else if (user == null) {
-            return res.status(404).render("error", {
-                message: "There was no user."
+            database.userById(formatting.hexToBin(req.params.name), function (err, user) {
+                if (err) {
+                    return res.status(500).render("error", {
+                        message: "There was an error fetching from the database."
+                    });
+                } else if (user == null) {
+                    return res.status(404).render("error", {
+                        message: "There was no user."
+                    });
+                } else {
+                    return res.redirect("/user/profile/" + user.ShortName);
+                }
             });
         } else {
             user.UserID = formatting.binToHex(user.UserID);

--- a/adventure/views/contribute.ejs
+++ b/adventure/views/contribute.ejs
@@ -1,0 +1,94 @@
+﻿<%- include("head", {title: "Contribute"}) %>
+<h1>Contribute</h1>
+<h2>Basic metadata</h2>
+<form method="post" action="/library/contribute/redirectToSecondStep">
+    <div class="row">
+        <div class="form-group col">
+            <label for="name">Name</label>
+            <input required type="text" class="form-control" id="name" name="name" placeholder="Name" value="">
+        </div>
+        <div class="form-group col">
+            <label for="vendorName">Vendor name</label>
+            <input type="text" class="form-control" id="vendorName" name="vendorName" placeholder="Vendor name" value="">
+        </div>
+    </div>
+    <%
+    // HACK: datetime-local != toISOString
+    function pad(number) {
+        if (number < 10) {
+            return '0' + number;
+        }
+        return number;
+    }
+    function shortIso(d) {
+        return d.getUTCFullYear() +
+        '-' + pad(d.getUTCMonth() + 1) +
+        '-' + pad(d.getUTCDate()) +
+        'T' + pad(d.getUTCHours()) +
+        ':' + pad(d.getUTCMinutes());
+    }
+    %>
+    <div class="row">
+        <div class="form-group col">
+            <label for="releaseDate">Release date</label>
+            <input type="datetime-local" class="form-control" id="releaseDate" name="releaseDate" placeholder="Release date" value="">
+            <small class="form-text text-muted">
+                If your browser doesn't support HTML 5 datetime fields, use a format like <pre>2000-02-15T06:00</pre>.
+            </small>
+        </div>
+        <div class="form-group col">
+            <label for="endOfLife">End of life  </label>
+            <input type="datetime-local" class="form-control" id="endOfLife" name="endOfLife" placeholder="End of life" value="">
+            <small class="form-text text-muted">
+                If your browser doesn't support HTML 5 datetime fields, use a format like <pre>2000-02-15T06:00</pre>.
+            </small>
+        </div>
+    </div>
+    <div class="row">
+        <div class="form-group col">
+            <label for="notes">Notes</label>
+            <textarea rows="5" class="form-control" id="notes" name="notes"></textarea>
+            <small class="form-text text-muted">
+                This field is formatted in Markdown
+            </small>
+        </div>
+        <div class="form-group col">
+            <label for="installInstructions">Installation instructions</label>
+            <textarea rows="5" class="form-control" id="installInstructions" name="installInstructions"></textarea>
+            <small class="form-text text-muted">
+                This field is formatted in Markdown
+            </small>
+        </div>
+    </div>
+    <div class="form-group">
+        <label for="platform">Platforms</label>
+        <select multiple class="form-control" id="platform" name="platform">
+            <% Object.keys(platformMappingsInverted).forEach(function (i, n, a) { %>
+            <option><%= i %></option>
+            <% }); %>
+        </select>
+    </div>
+    <div class="row">
+        <div class="form-group col">
+            <label for="cpuRequirement">Required CPU</label>
+            <input type="text" class="form-control" id="cpuRequirement" name="cpuRequirement" placeholder="Required CPU" value="">
+        </div>
+        <div class="form-group col">
+            <label for="ramRequirement">Required RAM</label>
+            <input required type="number" class="form-control" id="ramRequirement" name="ramRequirement" placeholder="Required RAM" value="">
+            <small class="form-text text-muted">
+                This field is converted to the most sensible human-readable byte size. Enter 0 to blank.
+            </small>
+        </div>
+        <div class="form-group col">
+            <label for="diskSpaceRequired">Required free disk space</label>
+            <input required type="number" class="form-control" id="diskSpaceRequired" name="diskSpaceRequired" placeholder="Required free disk space" value="">
+            <small class="form-text text-muted">
+                This field is converted to the most sensible human-readable byte size. Enter 0 to blank.
+            </small>
+        </div>
+    </div>
+    <button type="submit" class="btn btn-primary">Next Step</button>
+    <a class="btn btn-outline-primary" href="/library">Cancel</a>
+</form>
+<%- include("foot") %>

--- a/adventure/views/contribute.ejs
+++ b/adventure/views/contribute.ejs
@@ -4,8 +4,12 @@
 <form method="post" action="/library/contribute/redirectToSecondStep">
     <div class="row">
         <div class="form-group col">
-            <label for="name">Name</label>
-            <input required type="text" class="form-control" id="name" name="name" placeholder="Name" value="">
+            <label for="name">Product name</label>
+            <input required type="text" class="form-control" id="productName" name="productName" placeholder="Product name" value="">
+        </div>
+        <div class="form-group col">
+            <label for="name">Release name</label>
+            <input required type="text" class="form-control" id="name" name="name" placeholder="Release name" value="">
         </div>
         <div class="form-group col">
             <label for="vendorName">Vendor name</label>

--- a/adventure/views/contribute.ejs
+++ b/adventure/views/contribute.ejs
@@ -6,10 +6,16 @@
         <div class="form-group col">
             <label for="name">Product name</label>
             <input required type="text" class="form-control" id="productName" name="productName" placeholder="Product name" value="">
+            <small class="form-text text-muted">
+                e.g. Windows 95
+            </small>
         </div>
         <div class="form-group col">
             <label for="name">Release name</label>
             <input required type="text" class="form-control" id="name" name="name" placeholder="Release name" value="">
+            <small class="form-text text-muted">
+                e.g. OSR2
+            </small>
         </div>
         <div class="form-group col">
             <label for="vendorName">Vendor name</label>

--- a/adventure/views/editProfile.ejs
+++ b/adventure/views/editProfile.ejs
@@ -1,5 +1,6 @@
 <%- include("head", {title: "Edit profile"}) %>
 <h1>Edit profile</h1>
+<a href="/user/profile/<%= user.ShortName %>" class="btn btn-primary">View profile</a>
 <h2>Details</h2>
 <form>
     <div class="form-group">

--- a/adventure/views/head.ejs
+++ b/adventure/views/head.ejs
@@ -79,6 +79,7 @@
                         <%= user.ShortName %>
                     </a>
                     <div class="dropdown-menu dropdown-menu-right" aria-labelledby="userMenuLink">
+                        <a class="dropdown-item" href="/user/profile">View profile</a>
                         <a class="dropdown-item" href="/user/edit">Edit profile</a>
                         <a class="dropdown-item" href="/user/logout">Log out</a>
                     </div>

--- a/adventure/views/head.ejs
+++ b/adventure/views/head.ejs
@@ -79,6 +79,7 @@
                         <%= user.ShortName %>
                     </a>
                     <div class="dropdown-menu dropdown-menu-right" aria-labelledby="userMenuLink">
+                        <a class="dropdown-item" href="/library/my/contributions">My contributions</a>
                         <a class="dropdown-item" href="/user/profile">View profile</a>
                         <a class="dropdown-item" href="/user/edit">Edit profile</a>
                         <a class="dropdown-item" href="/user/logout">Log out</a>

--- a/adventure/views/library.ejs
+++ b/adventure/views/library.ejs
@@ -3,7 +3,9 @@
     <% for (var i in categoryMappings) { %>
     <a class="nav-link <%= category == i ? 'active' : '' %>" href="/library/<%= i %>"><%= categoryMappings[i] %></a>
     <% } %>
+    <% if (config.allowContributions) { %>
     <a class="btn btn-outline-info ml-2" id="contributeButton" href="/library/contribute">Contribute</a>
+    <% } %>
 </nav>
 <dl id="libraryList">
     <% products.forEach(function(i, n, a) {%>

--- a/adventure/views/library.ejs
+++ b/adventure/views/library.ejs
@@ -3,6 +3,7 @@
     <% for (var i in categoryMappings) { %>
     <a class="nav-link <%= category == i ? 'active' : '' %>" href="/library/<%= i %>"><%= categoryMappings[i] %></a>
     <% } %>
+    <a class="btn btn-outline-info ml-2" id="contributeButton" href="/library/contribute">Contribute</a>
 </nav>
 <dl id="libraryList">
     <% products.forEach(function(i, n, a) {%>

--- a/adventure/views/libraryOS.ejs
+++ b/adventure/views/libraryOS.ejs
@@ -3,7 +3,9 @@
     <% for (var i in categoryMappings) { %>
     <a class="nav-link <%= 'operating-systems' == i ? 'active' : '' %>" href="/library/<%= i %>"><%= categoryMappings[i] %></a>
     <% } %>
+    <% if (config.allowContributions) { %>
     <a class="btn btn-outline-info ml-2" id="contributeButton" href="/library/contribute">Contribute</a>
+    <% } %>
 </nav>
 <div class="row">
     <div class="col-md-3">

--- a/adventure/views/libraryOS.ejs
+++ b/adventure/views/libraryOS.ejs
@@ -3,6 +3,7 @@
     <% for (var i in categoryMappings) { %>
     <a class="nav-link <%= 'operating-systems' == i ? 'active' : '' %>" href="/library/<%= i %>"><%= categoryMappings[i] %></a>
     <% } %>
+    <a class="btn btn-outline-info ml-2" id="contributeButton" href="/library/contribute">Contribute</a>
 </nav>
 <div class="row">
     <div class="col-md-3">

--- a/adventure/views/mycontributions.ejs
+++ b/adventure/views/mycontributions.ejs
@@ -1,0 +1,63 @@
+<%- include("head", {title: "My contributions"}) %>
+<h1>My contributions</h1>
+<table id="saContributionsTable" class="table table-striped table-sm table-responsive">
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Status</th>
+        </tr>
+    </thead>
+    <tbody>
+        <% (contributions || []).forEach(function(i, n, a) {%>
+        <tr>
+            <td>
+                <%= i.ProductTitle %> <%= i.ReleaseTitle %>
+            </td>
+            <td>
+                <%= i.Status %> (<%= i.Status == "Rejected" && i.RejectionReason ? i.RejectionReason : i.ContributionCreated.toDateString() %>)
+            </td>
+        </tr>
+        <% }); %>
+    </tbody>
+</table>
+<nav aria-label="Page navigation">
+    <ul id="contributionsPagination" class="pagination">
+        <%# HACK: How the hell does EJS get a string when we passed a number? %>
+        <% page = Number(page); pageBounds = config.perPageBounds; %>
+        <%# Anyways, do bounds checking so we can make the pagination manageable. %>
+        <% if (page - pageBounds > 1) { %>
+                <li class="page-item">
+                    <a class="page-link" href="/library/my/contributions?page=1">1</a>
+                </li>
+        <% } %>
+        <% if (page - pageBounds > 2) { %>
+                <li class="page-item disabled">
+                    <a class="page-link" href="#" tabindex="-1">...</a>
+                </li>
+        <% } %>
+        <% for (var i = page - pageBounds > 0 ? page - pageBounds : 1; i <= (page + pageBounds < pages ? page + pageBounds : pages); i++) { %>
+            <% if (i != page) { %>
+                <li class="page-item">
+                    <a class="page-link" href="/library/my/contributions?page=<%= i %>"><%= i %></a>
+                </li>
+            <% } else { %>
+                <li class="page-item active">
+                    <a class="page-link" href="/library/my/contributions?page=<%= i %>">
+                        <%= i %><span class="sr-only">(current)</span>
+                    </a>
+                </li>
+            <% } %>
+        <% } %>
+        <% if (page + pageBounds < pages - 1) { %>
+                <li class="page-item disabled">
+                    <a class="page-link" href="#" tabindex="-1">...</a>
+                </li>
+        <% } %>
+        <% if (page + pageBounds < pages) { %>
+                <li class="page-item">
+                    <a class="page-link" href="/library/my/contributions?page=<%= pages %>"><%= pages %></a>
+                </li>
+        <% } %>
+    </ul>
+</nav>
+<%- include("foot") %>

--- a/adventure/views/publicProfile.ejs
+++ b/adventure/views/publicProfile.ejs
@@ -7,12 +7,18 @@
 <% }); %>
 <% } %>
 </p>
-<p><strong>Joined</strong> <%= viewingUser.RegistrationTime %></p>
-<p><strong>Last Active</strong> <%= viewingUser.LastSeenTime %></p>
-<% if (config.usersCanChangeTheme) { %>
+<p><strong>Joined</strong> <%= new Date(viewingUser.RegistrationTime).toLocaleDateString() %></p>
+<p><strong>Last Active</strong> <%= new Date(viewingUser.LastSeenTime).toLocaleString() %></p>
+<% if (user && config.usersCanChangeTheme) { %>
 <p><strong>Using Theme</strong> <%= viewingUser.ThemeName %></p>
 <% } %>
 <% if (config.useVanilla) { %>
 <p><a href="<%= config.vanillaBaseUrl %>/profile/<%= viewingUser.ShortName %>">Show profile on forum</a></p>
+<% } %>
+<% if (user && user.UserFlags.some(function (x) { return x.FlagName == "sa"; })) { %>
+<p><a href="/sa/user/<%= viewingUser.UserID %>">Manage user</a></p>
+<% } %>
+<% if (user && user.ShortName == viewingUser.ShortName) { %>
+<p><a href="/user/edit">Edit profile</a></p>
 <% } %>
 <%- include("foot") %>

--- a/adventure/views/publicProfile.ejs
+++ b/adventure/views/publicProfile.ejs
@@ -1,0 +1,18 @@
+<%- include("head", {title: viewingUser.ShortName + "\'s Profile"}) %>
+<h1><%= viewingUser.ShortName %></h1>
+<p>
+<% if (viewingUser.UserFlags && viewingUser.UserFlags.length > 0) { %>
+<% viewingUser.UserFlags.forEach(function (i, n, a) { %>
+<span class="badge badge-<%= i.FlagColour %>"><%= i.LongName %></span>
+<% }); %>
+<% } %>
+</p>
+<p><strong>Joined</strong> <%= viewingUser.RegistrationTime %></p>
+<p><strong>Last Active</strong> <%= viewingUser.LastSeenTime %></p>
+<% if (config.usersCanChangeTheme) { %>
+<p><strong>Using Theme</strong> <%= viewingUser.ThemeName %></p>
+<% } %>
+<% if (config.useVanilla) { %>
+<p><a href="<%= config.vanillaBaseUrl %>/profile/<%= viewingUser.ShortName %>">Show profile on forum</a></p>
+<% } %>
+<%- include("foot") %>

--- a/adventure/views/saContribution.ejs
+++ b/adventure/views/saContribution.ejs
@@ -4,8 +4,12 @@
 <form method="post" action="/sa/createReleaseFromContribution/<%= contribution.ContributionUUID %>">
     <div class="row">
         <div class="form-group col">
-            <label for="name">Name</label>
-            <input required type="text" class="form-control" id="name" name="name" placeholder="Name" value="<%= contribution.ReleaseTitle %>">
+            <label for="name">Product name</label>
+            <input required type="text" class="form-control" id="productName" name="productName" placeholder="Product name" value="<%= contribution.ProductTitle %>">
+        </div>
+        <div class="form-group col">
+            <label for="name">Release name</label>
+            <input required type="text" class="form-control" id="name" name="name" placeholder="Release name" value="<%= contribution.ReleaseTitle %>">
         </div>
         <div class="form-group col">
             <label for="vendorName">Vendor name</label>

--- a/adventure/views/saContribution.ejs
+++ b/adventure/views/saContribution.ejs
@@ -1,0 +1,102 @@
+﻿<%- include("head", {title: "Contribution: " + contribution.ProductTitle + " " + contribution.ReleaseTitle}) %>
+<h1>Contribution: <%= contribution.ProductTitle %> <%= contribution.ReleaseTitle %></h1>
+<h2>Basic metadata</h2>
+<form method="post" action="/sa/createReleaseFromContribution/<%= contribution.ContributionUUID %>">
+    <div class="row">
+        <div class="form-group col">
+            <label for="name">Name</label>
+            <input required type="text" class="form-control" id="name" name="name" placeholder="Name" value="<%= contribution.ReleaseTitle %>">
+        </div>
+        <div class="form-group col">
+            <label for="vendorName">Vendor name</label>
+            <input type="text" class="form-control" id="vendorName" name="vendorName" placeholder="Vendor name" value="<%= contribution.VendorName %>">
+        </div>
+    </div>
+    <%
+    // HACK: datetime-local != toISOString
+    function pad(number) {
+        if (number < 10) {
+            return '0' + number;
+        }
+        return number;
+    }
+    function shortIso(d) {
+        return d.getUTCFullYear() +
+        '-' + pad(d.getUTCMonth() + 1) +
+        '-' + pad(d.getUTCDate()) +
+        'T' + pad(d.getUTCHours()) +
+        ':' + pad(d.getUTCMinutes());
+    }
+    %>
+    <div class="row">
+        <div class="form-group col">
+            <label for="releaseDate">Release date</label>
+            <input type="datetime-local" class="form-control" id="releaseDate" name="releaseDate" placeholder="Release date" value="<%= contribution.ReleaseDate && contribution.ReleaseDate.getTime() ? shortIso(contribution.ReleaseDate) : '' %>">
+            <small class="form-text text-muted">
+                If your browser doesn't support HTML 5 datetime fields, use a format like <pre>2000-02-15T06:00</pre>.
+            </small>
+        </div>
+        <div class="form-group col">
+            <label for="endOfLife">End of life  </label>
+            <input type="datetime-local" class="form-control" id="endOfLife" name="endOfLife" placeholder="End of life" value="<%= contribution.EOLDate && contribution.EOLDate.getTime() ? shortIso(rcontribution.EOLDate) : '' %>">
+            <small class="form-text text-muted">
+                If your browser doesn't support HTML 5 datetime fields, use a format like <pre>2000-02-15T06:00</pre>.
+            </small>
+        </div>
+    </div>
+    <div class="row">
+        <div class="form-group col">
+            <label for="notes">Notes</label>
+            <textarea rows="5" class="form-control" id="notes" name="notes"><%= contribution.AboutRelease %></textarea>
+            <small class="form-text text-muted">
+                This field is formatted in Markdown
+            </small>
+        </div>
+        <div class="form-group col">
+            <label for="installInstructions">Installation instructions</label>
+            <textarea rows="5" class="form-control" id="installInstructions" name="installInstructions"><%= contribution.InstallInstructions %></textarea>
+            <small class="form-text text-muted">
+                This field is formatted in Markdown
+            </small>
+        </div>
+    </div>
+    <div class="form-group">
+        <label for="platform">Platforms</label>
+        <select multiple class="form-control" id="platform" name="platform">
+            <% Object.keys(platformMappingsInverted).forEach(function (i, n, a) { %>
+            <option <%= contribution.Platform && contribution.Platform.indexOf(i) > -1 ? "selected" : "" %>><%= i %></option>
+            <% }); %>
+        </select>
+    </div>
+    <div class="row">
+        <div class="form-group col">
+            <label for="cpuRequirement">Required CPU</label>
+            <input type="text" class="form-control" id="cpuRequirement" name="cpuRequirement" placeholder="Required CPU" value="<%= contribution.CPURequirement %>">
+        </div>
+        <div class="form-group col">
+            <label for="ramRequirement">Required RAM</label>
+            <input required type="number" class="form-control" id="ramRequirement" name="ramRequirement" placeholder="Required RAM" value="<%= contribution.RAMRequirement || 0 %>">
+            <small class="form-text text-muted">
+                This field is converted to the most sensible human-readable byte size. Enter 0 to blank.
+            </small>
+        </div>
+        <div class="form-group col">
+            <label for="diskSpaceRequired">Required free disk space</label>
+            <input required type="number" class="form-control" id="diskSpaceRequired" name="diskSpaceRequired" placeholder="Required free disk space" value="<%= contribution.DiskRequirement || 0 %>">
+            <small class="form-text text-muted">
+                This field is converted to the most sensible human-readable byte size. Enter 0 to blank.
+            </small>
+        </div>
+    </div>
+    <button type="submit" class="btn btn-primary">Create Release</button>
+    <a class="btn btn-outline-primary" href="/sa/contributions">Cancel</a>
+</form>
+<h2>Reject contribution</h2>
+<form method="post" action="/sa/rejectContribution/<%= contribution.ContributionUUID %>">
+    <div class="form-group">
+        <label for="name">Reason</label>
+        <input required type="text" class="form-control" id="rejectionReason" name="rejectionReason" placeholder="Rejection reason" value="<%= contribution.RejectionReason %>">
+    </div>
+    <button type="submit" id="saContributionRejectSubmit" class="btn btn-danger">Reject Contribution</button>
+</form>
+<%- include("foot") %>

--- a/adventure/views/saContribution.ejs
+++ b/adventure/views/saContribution.ejs
@@ -6,10 +6,16 @@
         <div class="form-group col">
             <label for="name">Product name</label>
             <input required type="text" class="form-control" id="productName" name="productName" placeholder="Product name" value="<%= contribution.ProductTitle %>">
+            <small class="form-text text-muted">
+                e.g. Windows 95
+            </small>
         </div>
         <div class="form-group col">
             <label for="name">Release name</label>
             <input required type="text" class="form-control" id="name" name="name" placeholder="Release name" value="<%= contribution.ReleaseTitle %>">
+            <small class="form-text text-muted">
+                e.g. OSR2
+            </small>
         </div>
         <div class="form-group col">
             <label for="vendorName">Vendor name</label>

--- a/adventure/views/saContributions.ejs
+++ b/adventure/views/saContributions.ejs
@@ -14,7 +14,7 @@
             <td>
                 <a href="/sa/contribution/<%= i.ContributionUUID %>"><%= i.ProductTitle %> <%= i.ReleaseTitle %></a>
             </td>
-            <td><a href="/sa/user/<%= i.UserUUID %>"><%= i.UserUUID %></a></td>
+            <td><a href="/user/profile/<%= i.UserUUID %>"><%= i.UserUUID %></a></td>
             <td>
                 <%= i.Status %> (<%= i.Status == "Rejected" && i.RejectionReason ? i.RejectionReason : i.ContributionCreated.toDateString() %>)
             </td>

--- a/adventure/views/saContributions.ejs
+++ b/adventure/views/saContributions.ejs
@@ -1,4 +1,5 @@
-﻿<%- include("head", {title: "Contributions"}) %>
+<%- include("head", {title: "Contributions"}) %>
+<h1>Contributions</h1>
 <table id="saContributionsTable" class="table table-striped table-sm table-responsive">
     <thead>
         <tr>
@@ -11,11 +12,11 @@
         <% (contributions || []).forEach(function(i, n, a) {%>
         <tr>
             <td>
-                <a href="/sa/contribution/<%= i.ContributionUUID %>"><%= i.ReleaseTitle %></a>
+                <a href="/sa/contribution/<%= i.ContributionUUID %>"><%= i.ProductTitle %> <%= i.ReleaseTitle %></a>
             </td>
             <td><%= i.UserUUID %></td>
             <td>
-                <%= i.Status %> (<%= i.ContributionCreated.toDateString() %>)
+                <%= i.Status %> (<%= i.Status == "Rejected" && i.RejectionReason ? i.RejectionReason : i.ContributionCreated.toDateString() %>)
             </td>
         </tr>
         <% }); %>

--- a/adventure/views/saContributions.ejs
+++ b/adventure/views/saContributions.ejs
@@ -14,7 +14,7 @@
             <td>
                 <a href="/sa/contribution/<%= i.ContributionUUID %>"><%= i.ProductTitle %> <%= i.ReleaseTitle %></a>
             </td>
-            <td><%= i.UserUUID %></td>
+            <td><a href="/sa/user/<%= i.UserUUID %>"><%= i.UserUUID %></a></td>
             <td>
                 <%= i.Status %> (<%= i.Status == "Rejected" && i.RejectionReason ? i.RejectionReason : i.ContributionCreated.toDateString() %>)
             </td>

--- a/adventure/views/saUser.ejs
+++ b/adventure/views/saUser.ejs
@@ -1,5 +1,6 @@
 <%- include("head", {title: "Editing user " + editingUser.ShortName}) %>
 <h1>Editing user <var><%= editingUser.ShortName  %></var></h1>
+<a href="/user/profile/<%= editingUser.ShortName %>" class="btn btn-primary">View profile</a>
 <h2>Details</h2>
 <form>
     <div class="form-group">


### PR DESCRIPTION
This PR adds the following:
* Public profile pages, viewable by going to `/user/profile/<username>` or `/user/profile/<uuid>`, or, to view their own profile, users can go to `/user/profile` or click the link in the user menu.
* Admin interface for viewing and rejecting contributions, including a reason why it was rejected.
* Users can view, but not edit, their own contributions, if any, by going to `/library/my/contributions` ([same route as before](https://forum.winworldpc.com/discussion/9571/suggestion-quot-my-active-contributions-quot-page-for-the-library)) or clicking the link in the user menu.
* Ability to accept new contributions is controlled by a config switch, `allowContributions` (boolean).
* The route `/library/contribute` is now operable, but largely incomplete. For now, I recommend setting the setting mentioned above to `false`, and advising admins to not click "Create Release" in the admin interface contribution page.